### PR TITLE
fix: Phase 4c — ObstacleMonitor bug fixes + observability

### DIFF
--- a/docs/superpowers/plans/2026-03-20-phase4c-obstacle-monitor-bugfixes.md
+++ b/docs/superpowers/plans/2026-03-20-phase4c-obstacle-monitor-bugfixes.md
@@ -1,0 +1,773 @@
+# Phase 4c: ObstacleMonitor Bug Fixes + Observability — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three event-publishing bugs discovered during pipeline testing and add
+structured logging so future failures are diagnosable in minutes, not hours.
+
+**Architecture:** Surgical fixes at three points in the event-publishing chain:
+(1) callback exception handling in `_poll_loop`, (2) RTH guards in
+`ObstacleResponseHandler`, (3) publish-after-success in flight tools. Plus
+structured log events at all decision points and status methods on monitor/handler.
+
+**Tech Stack:** Python 3.13, pytest + pytest-asyncio, structlog, AsyncMock/MagicMock
+
+**Spec:** `docs/superpowers/specs/2026-03-20-phase4c-obstacle-monitor-bugfixes-design.md`
+
+**Session context recovery:** This plan references MEMORY.md for current state.
+After each task, the implementer should update MEMORY.md with progress. Key files:
+- `feedback_implementation_checklist.md` — mandatory workflow steps
+- `feedback_always_run_telemetry.md` — tello-telemetry must run during physical tests
+- `project_phase4b_physical_test_results.md` — test run data (Runs 1-3)
+
+---
+
+## File Structure
+
+**Modified files (no new files created):**
+
+| File | Responsibility | Changes |
+|------|---------------|---------|
+| `services/tello-mcp/src/tello_mcp/obstacle.py` | Obstacle detection + RTH | Callback try/except, RTH guards, status methods, state reset, logging |
+| `services/tello-mcp/src/tello_mcp/telemetry.py` | Redis event publishing | Wrap xadd in try/except, structured log events |
+| `services/tello-mcp/src/tello_mcp/tools/flight.py` | MCP flight tools | Publish-after-success for takeoff/land, add logger |
+| `services/tello-mcp/tests/test_obstacle.py` | Obstacle tests | New tests for guards, callback resilience, status |
+| `services/tello-mcp/tests/test_tools/test_flight.py` | Flight tool tests | New tests for publish-on-failure |
+| `services/tello-mcp/tests/test_telemetry.py` | Telemetry tests | New test for xadd failure handling |
+
+---
+
+## Task 1: Callback Exception Handling in `_poll_loop` (Bug #1)
+
+**Files:**
+- Modify: `services/tello-mcp/tests/test_obstacle.py`
+- Modify: `services/tello-mcp/src/tello_mcp/obstacle.py:176-179`
+
+- [ ] **Step 1: Write the failing test — callback exception doesn't kill the monitor**
+
+Add to `TestObstacleMonitorPolling` in `services/tello-mcp/tests/test_obstacle.py`:
+
+```python
+async def test_callback_exception_does_not_kill_monitor(self):
+    """Poll loop survives a callback that raises an exception."""
+    drone = MagicMock()
+    drone.get_forward_distance.return_value = {"status": "ok", "distance_mm": 600}
+    config = ObstacleConfig(poll_interval_ms=50)
+    monitor = ObstacleMonitor(drone, config)
+
+    call_count = 0
+
+    def exploding_callback(reading):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    monitor.on_reading(exploding_callback)
+    await monitor.start()
+    await asyncio.sleep(0.2)
+    await monitor.stop()
+    # The callback was called more than once — the loop survived the exception
+    assert call_count >= 2
+
+async def test_callback_exception_is_logged(self, caplog):
+    """Callback exception is logged for diagnosis."""
+    drone = MagicMock()
+    drone.get_forward_distance.return_value = {"status": "ok", "distance_mm": 600}
+    config = ObstacleConfig(poll_interval_ms=50)
+    monitor = ObstacleMonitor(drone, config)
+
+    def exploding_callback(reading):
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    monitor.on_reading(exploding_callback)
+    await monitor.start()
+    await asyncio.sleep(0.15)
+    await monitor.stop()
+    assert "callback_failed" in caplog.text or "boom" in caplog.text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/test_obstacle.py::TestObstacleMonitorPolling::test_callback_exception_does_not_kill_monitor -v`
+
+Expected: FAIL — `RuntimeError: boom` propagates and kills the poll loop, so
+`call_count` stays at 1.
+
+- [ ] **Step 3: Write the fix — wrap callbacks in try/except**
+
+In `services/tello-mcp/src/tello_mcp/obstacle.py`, replace lines 176-179:
+
+```python
+# BEFORE:
+                for cb in self._callbacks:
+                    cb_result = cb(reading)
+                    if asyncio.iscoroutine(cb_result):
+                        await cb_result
+```
+
+With:
+
+```python
+# AFTER:
+                for cb in self._callbacks:
+                    try:
+                        cb_result = cb(reading)
+                        if asyncio.iscoroutine(cb_result):
+                            await cb_result
+                    except Exception:
+                        logger.exception(
+                            "obstacle.callback_failed",
+                            distance_mm=reading.distance_mm,
+                            zone=reading.zone.value,
+                        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/test_obstacle.py::TestObstacleMonitorPolling::test_callback_exception_does_not_kill_monitor -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/tello-mcp/src/tello_mcp/obstacle.py services/tello-mcp/tests/test_obstacle.py
+git commit -m "fix: wrap poll loop callbacks in try/except (Bug #1)
+
+Unhandled exceptions in ObstacleMonitor callbacks silently killed event
+publishing. Now logged and the poll loop continues running."
+```
+
+---
+
+## Task 2: RTH Guards — `_rth_active` flag + grounded check (Bug #2)
+
+**Files:**
+- Modify: `services/tello-mcp/tests/test_obstacle.py`
+- Modify: `services/tello-mcp/src/tello_mcp/obstacle.py:200-277`
+
+- [ ] **Step 1: Write the failing tests — RTH guards**
+
+Add a new test class in `services/tello-mcp/tests/test_obstacle.py`:
+
+```python
+class TestRTHGuards:
+    """Tests for on_obstacle_reading guards that prevent re-entry and grounded RTH."""
+
+    def _make_handler(self):
+        drone = MagicMock()
+        drone.safe_land.return_value = {"status": "ok"}
+        strategy = MagicMock()
+        strategy.return_to_home.return_value = {
+            "status": "returned",
+            "method": "simple_reverse",
+            "reversed_direction": "back",
+            "height_cm": 80,
+            "forward_distance_mm": 185,
+            "landed": True,
+        }
+        telemetry = AsyncMock()
+        telemetry.publish_event = AsyncMock()
+        handler = ObstacleResponseHandler(
+            drone=drone,
+            rth_strategy=strategy,
+            telemetry=telemetry,
+            last_command={"direction": "forward", "distance_cm": 50},
+        )
+        return handler, drone, strategy, telemetry
+
+    async def test_rth_skipped_when_active(self):
+        """on_obstacle_reading returns immediately if RTH is already in progress."""
+        handler, _drone, strategy, _tel = self._make_handler()
+        handler._rth_active = True
+
+        reading = ObstacleReading(
+            distance_mm=185,
+            zone=ObstacleZone.DANGER,
+            timestamp=datetime(2026, 3, 20),
+        )
+        await handler.on_obstacle_reading(reading)
+        strategy.return_to_home.assert_not_called()
+
+    async def test_rth_skipped_when_grounded(self):
+        """on_obstacle_reading returns immediately if drone is on the ground."""
+        handler, drone, strategy, _tel = self._make_handler()
+        drone.get_height.return_value = {"status": "ok", "height_cm": 0}
+
+        reading = ObstacleReading(
+            distance_mm=185,
+            zone=ObstacleZone.DANGER,
+            timestamp=datetime(2026, 3, 20),
+        )
+        await handler.on_obstacle_reading(reading)
+        strategy.return_to_home.assert_not_called()
+
+    async def test_rth_not_skipped_when_height_query_fails(self):
+        """A failed get_height must NOT suppress RTH — drone may be airborne."""
+        handler, drone, strategy, _tel = self._make_handler()
+        drone.get_height.return_value = {"error": "HEIGHT_FAILED", "detail": "timeout"}
+
+        reading = ObstacleReading(
+            distance_mm=185,
+            zone=ObstacleZone.DANGER,
+            timestamp=datetime(2026, 3, 20),
+        )
+        await handler.on_obstacle_reading(reading)
+        strategy.return_to_home.assert_called_once()
+
+    async def test_rth_active_flag_set_during_execution(self):
+        """_rth_active is True while execute() is running, False after."""
+        handler, drone, strategy, _tel = self._make_handler()
+        drone.get_height.return_value = {"status": "ok", "height_cm": 80}
+
+        observed_during: list[bool] = []
+        original_execute = handler.execute
+
+        async def spy_execute(*args, **kwargs):
+            observed_during.append(handler._rth_active)
+            return await original_execute(*args, **kwargs)
+
+        handler.execute = spy_execute
+
+        reading = ObstacleReading(
+            distance_mm=185,
+            zone=ObstacleZone.DANGER,
+            timestamp=datetime(2026, 3, 20),
+        )
+        await handler.on_obstacle_reading(reading)
+        assert observed_during == [True]
+        assert handler._rth_active is False
+
+    async def test_rth_active_flag_cleared_on_exception(self):
+        """_rth_active is cleared even if execute() raises."""
+        handler, drone, _strategy, _tel = self._make_handler()
+        drone.get_height.return_value = {"status": "ok", "height_cm": 80}
+        handler.execute = AsyncMock(side_effect=RuntimeError("execute failed"))
+
+        reading = ObstacleReading(
+            distance_mm=185,
+            zone=ObstacleZone.DANGER,
+            timestamp=datetime(2026, 3, 20),
+        )
+        # Should not propagate — the callback exception guard from Task 1
+        # would catch this in production, but we test the flag cleanup here.
+        with pytest.raises(RuntimeError, match="execute failed"):
+            await handler.on_obstacle_reading(reading)
+        assert handler._rth_active is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/test_obstacle.py::TestRTHGuards -v`
+
+Expected: FAIL — `_rth_active` attribute doesn't exist, grounded check not implemented.
+
+- [ ] **Step 3: Write the fix — add `_rth_active` flag and grounded guard**
+
+In `services/tello-mcp/src/tello_mcp/obstacle.py`, modify `ObstacleResponseHandler`:
+
+Add `_rth_active` to `__init__` (after line 210):
+```python
+        self._last_command = last_command
+        self._rth_active = False
+```
+
+Replace `on_obstacle_reading` method (lines 256-277) with:
+```python
+    async def on_obstacle_reading(self, reading: ObstacleReading) -> None:
+        """Callback for ObstacleMonitor — auto-triggers RTH on DANGER.
+
+        Guards:
+        - Ignores non-DANGER readings
+        - Skips if RTH is already in progress (_rth_active flag)
+        - Skips if drone is confirmed on the ground (height_cm == 0)
+        - Does NOT skip if get_height fails (drone may be airborne)
+        """
+        if reading.zone != ObstacleZone.DANGER:
+            return
+
+        if self._rth_active:
+            logger.debug("obstacle.rth_skipped_active", distance_mm=reading.distance_mm)
+            return
+
+        last_cmd = self._last_command or {}
+        height_result = await asyncio.to_thread(self._drone.get_height)
+        height_cm = height_result.get("height_cm", 0) if height_result.get("status") == "ok" else 0
+
+        if height_result.get("status") == "ok" and height_cm == 0:
+            logger.debug(
+                "obstacle.rth_skipped_grounded",
+                height_cm=height_cm,
+                distance_mm=reading.distance_mm,
+            )
+            return
+
+        self._rth_active = True
+        try:
+            logger.info(
+                "obstacle.rth_started",
+                distance_mm=reading.distance_mm,
+                height_cm=height_cm,
+                last_direction=last_cmd.get("direction", ""),
+            )
+            context = ObstacleContext(
+                last_direction=last_cmd.get("direction", ""),
+                last_distance_cm=int(last_cmd.get("distance_cm", 0)),
+                height_cm=height_cm,
+                forward_distance_mm=reading.distance_mm,
+                mission_id=last_cmd.get("mission_id"),
+                room_id=last_cmd.get("room_id"),
+            )
+            result = await self.execute(ObstacleResponse.RETURN_TO_HOME, context)
+            logger.info(
+                "obstacle.rth_completed",
+                outcome=result.get("status", "unknown"),
+                reversed_direction=result.get("reversed_direction"),
+            )
+        finally:
+            self._rth_active = False
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/test_obstacle.py::TestRTHGuards -v`
+
+Expected: PASS (all 5 tests)
+
+- [ ] **Step 5: Run full obstacle test suite to verify no regressions**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/test_obstacle.py -v`
+
+Expected: All tests PASS (existing + new)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/tello-mcp/src/tello_mcp/obstacle.py services/tello-mcp/tests/test_obstacle.py
+git commit -m "fix: add RTH guards — rth_active flag + grounded check (Bug #2)
+
+Prevents post-landing infinite DANGER loop and duplicate RTH execution.
+Height guard only fires on confirmed ground reading — failed get_height
+does not suppress RTH (safety-critical)."
+```
+
+---
+
+## Task 3: Publish-After-Success in Flight Tools (Bug #3)
+
+**Files:**
+- Modify: `services/tello-mcp/tests/test_tools/test_flight.py`
+- Modify: `services/tello-mcp/src/tello_mcp/tools/flight.py`
+
+- [ ] **Step 1: Write the failing tests — events not published on SDK failure**
+
+Add to `TestFlightTools` in `services/tello-mcp/tests/test_tools/test_flight.py`:
+
+```python
+async def test_takeoff_does_not_publish_on_failure(self):
+    """Takeoff event is NOT published when SDK command fails."""
+    mock_queue = AsyncMock()
+    mock_queue.enqueue = AsyncMock(return_value={"error": "COMMAND_FAILED", "detail": "timeout"})
+    mock_telemetry = AsyncMock()
+    ctx = self._make_ctx(queue=mock_queue, telemetry=mock_telemetry)
+    await self.registered_tools["takeoff"](ctx, room_id="living-room")
+    mock_telemetry.publish_event.assert_not_called()
+
+async def test_land_does_not_publish_on_failure(self):
+    """Land event is NOT published when SDK command fails."""
+    mock_queue = AsyncMock()
+    mock_queue.enqueue = AsyncMock(return_value={"error": "LAND_FAILED", "detail": "timeout"})
+    mock_telemetry = AsyncMock()
+    ctx = self._make_ctx(queue=mock_queue, telemetry=mock_telemetry)
+    await self.registered_tools["land"](ctx)
+    mock_telemetry.publish_event.assert_not_called()
+
+async def test_land_publishes_on_success(self):
+    """Land event IS published when SDK command succeeds."""
+    mock_queue = AsyncMock()
+    mock_queue.enqueue = AsyncMock(return_value={"status": "ok"})
+    mock_telemetry = AsyncMock()
+    ctx = self._make_ctx(queue=mock_queue, telemetry=mock_telemetry)
+    await self.registered_tools["land"](ctx)
+    mock_telemetry.publish_event.assert_called_once()
+    assert mock_telemetry.publish_event.call_args[0][0] == "land"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/test_tools/test_flight.py::TestFlightTools::test_takeoff_does_not_publish_on_failure services/tello-mcp/tests/test_tools/test_flight.py::TestFlightTools::test_land_does_not_publish_on_failure services/tello-mcp/tests/test_tools/test_flight.py::TestFlightTools::test_land_publishes_on_success -v`
+
+Expected: `test_takeoff_does_not_publish_on_failure` FAIL, `test_land_does_not_publish_on_failure` FAIL (events published unconditionally). `test_land_publishes_on_success` should PASS.
+
+- [ ] **Step 3: Write the fix — gate event publishing on success**
+
+In `services/tello-mcp/src/tello_mcp/tools/flight.py`:
+
+Add a logger import between the third-party imports and the `if TYPE_CHECKING` block
+(i.e., after `from mcp.types import ToolAnnotations`, before `if TYPE_CHECKING:`):
+```python
+import structlog
+
+logger = structlog.get_logger("tello_mcp.tools.flight")
+```
+
+Replace the `takeoff` tool body (lines 27-29):
+```python
+        result = await queue.enqueue(drone.takeoff, heavy=True)
+        if result.get("status") == "ok":
+            await telemetry.publish_event("takeoff", {"room_id": room_id})
+        else:
+            logger.warning(
+                "event.skipped_command_failed",
+                event_type="takeoff",
+                error=result.get("error"),
+            )
+        return result
+```
+
+Replace the `land` tool body (lines 37-39):
+```python
+        result = await queue.enqueue(drone.safe_land)
+        if result.get("status") == "ok":
+            await telemetry.publish_event("land", {})
+        else:
+            logger.warning(
+                "event.skipped_command_failed",
+                event_type="land",
+                error=result.get("error"),
+            )
+        return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/test_tools/test_flight.py -v`
+
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/tello-mcp/src/tello_mcp/tools/flight.py services/tello-mcp/tests/test_tools/test_flight.py
+git commit -m "fix: publish events only after SDK success (Bug #3)
+
+Prevents orphaned FlightSessions when takeoff/land SDK commands fail.
+Event publishing now gated on result status check."
+```
+
+---
+
+## Task 4: TelemetryPublisher Error Handling
+
+**Files:**
+- Modify: `services/tello-mcp/tests/test_telemetry.py`
+- Modify: `services/tello-mcp/src/tello_mcp/telemetry.py`
+
+- [ ] **Step 1: Write the failing test — Redis xadd failure is caught**
+
+Add to `TestTelemetryPublisher` in `services/tello-mcp/tests/test_telemetry.py`:
+
+```python
+async def test_publish_event_logs_redis_failure(self, mock_redis):
+    """Redis xadd failure is caught and logged, not raised."""
+    mock_redis.xadd = AsyncMock(side_effect=ConnectionError("Redis down"))
+    publisher = TelemetryPublisher(
+        redis_client=mock_redis,
+        channel="tello:telemetry",
+        stream="tello:events",
+    )
+    # Should not raise
+    await publisher.publish_event("takeoff", {"room_id": "test"})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/test_telemetry.py::TestTelemetryPublisher::test_publish_event_logs_redis_failure -v`
+
+Expected: FAIL — `ConnectionError: Redis down` propagates.
+
+- [ ] **Step 3: Write the fix — wrap xadd in try/except**
+
+In `services/tello-mcp/src/tello_mcp/telemetry.py`, replace `publish_event`
+method (lines 47-56):
+
+```python
+    async def publish_event(self, event_type: str, data: dict[str, Any]) -> None:
+        """Publish a flight event to the Redis Stream.
+
+        Args:
+            event_type: Event type (e.g., "takeoff", "land", "move").
+            data: Event payload.
+        """
+        fields = {"event_type": event_type, **{k: str(v) for k, v in data.items()}}
+        try:
+            await self._redis.xadd(self._stream, fields)
+            logger.info("event.published", event_type=event_type)
+        except Exception:
+            logger.exception("event.publish_failed", event_type=event_type)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/test_telemetry.py -v`
+
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/tello-mcp/src/tello_mcp/telemetry.py services/tello-mcp/tests/test_telemetry.py
+git commit -m "fix: catch Redis xadd failures in TelemetryPublisher
+
+Prevents Redis connection errors from crashing event publishing.
+Failures are logged with structlog for diagnosis."
+```
+
+---
+
+## Task 5: Status Methods + State Reset
+
+**Files:**
+- Modify: `services/tello-mcp/tests/test_obstacle.py`
+- Modify: `services/tello-mcp/src/tello_mcp/obstacle.py`
+
+- [ ] **Step 1: Write the failing tests — status methods and state reset**
+
+Add to `services/tello-mcp/tests/test_obstacle.py`:
+
+```python
+class TestObstacleMonitorStatus:
+    def test_status_initial_state(self):
+        monitor = ObstacleMonitor(MagicMock())
+        status = monitor.status()
+        assert status == {
+            "running": False,
+            "in_danger": False,
+            "danger_clear_count": 0,
+            "latest_reading_mm": None,
+            "latest_zone": None,
+        }
+
+    async def test_status_after_start(self):
+        drone = MagicMock()
+        drone.get_forward_distance.return_value = {"status": "ok", "distance_mm": 600}
+        config = ObstacleConfig(poll_interval_ms=50)
+        monitor = ObstacleMonitor(drone, config)
+        await monitor.start()
+        await asyncio.sleep(0.1)
+        status = monitor.status()
+        assert status["running"] is True
+        assert status["latest_reading_mm"] == 600
+        assert status["latest_zone"] == "clear"
+        await monitor.stop()
+
+    async def test_start_resets_stale_state(self):
+        """Starting the monitor resets _in_danger and _danger_clear_count."""
+        drone = MagicMock()
+        drone.get_forward_distance.return_value = {"error": "EXHAUSTED"}
+        monitor = ObstacleMonitor(drone, ObstacleConfig(poll_interval_ms=50))
+        # Simulate stale state from a previous flight
+        monitor._in_danger = True
+        monitor._danger_clear_count = 2
+        await monitor.start()
+        assert monitor._in_danger is False
+        assert monitor._danger_clear_count == 0
+        await monitor.stop()
+
+
+class TestObstacleResponseHandlerStatus:
+    def test_status_initial(self):
+        handler = ObstacleResponseHandler(MagicMock())
+        assert handler.status() == {"rth_active": False}
+
+    def test_status_rth_active(self):
+        handler = ObstacleResponseHandler(MagicMock())
+        handler._rth_active = True
+        assert handler.status() == {"rth_active": True}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/test_obstacle.py::TestObstacleMonitorStatus services/tello-mcp/tests/test_obstacle.py::TestObstacleResponseHandlerStatus -v`
+
+Expected: FAIL — `status()` method doesn't exist.
+
+- [ ] **Step 3: Write the implementation — status methods + state reset**
+
+In `services/tello-mcp/src/tello_mcp/obstacle.py`:
+
+Add `status()` to `ObstacleMonitor` (after the `is_running` property, around line 116):
+```python
+    def status(self) -> dict:
+        """Current monitor state for diagnostics."""
+        return {
+            "running": self._running,
+            "in_danger": self._in_danger,
+            "danger_clear_count": self._danger_clear_count,
+            "latest_reading_mm": self._latest.distance_mm if self._latest else None,
+            "latest_zone": self._latest.zone.value if self._latest else None,
+        }
+```
+
+Modify `start()` to reset stale state (lines 122-128):
+```python
+    async def start(self) -> None:
+        """Start the background polling loop. Idempotent."""
+        if self._running:
+            return
+        self._in_danger = False
+        self._danger_clear_count = 0
+        self._running = True
+        self._task = asyncio.create_task(self._poll_loop())
+        logger.info("obstacle_monitor.started", poll_interval_ms=self._config.poll_interval_ms)
+```
+
+Add `status()` to `ObstacleResponseHandler` (after `__init__`, around line 211):
+```python
+    def status(self) -> dict:
+        """Current handler state for diagnostics."""
+        return {"rth_active": self._rth_active}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/test_obstacle.py::TestObstacleMonitorStatus services/tello-mcp/tests/test_obstacle.py::TestObstacleResponseHandlerStatus -v`
+
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/tello-mcp/src/tello_mcp/obstacle.py services/tello-mcp/tests/test_obstacle.py
+git commit -m "feat: add status methods + state reset for observability
+
+ObstacleMonitor.status() and ObstacleResponseHandler.status() expose
+internal state for diagnostics. Monitor start() resets stale danger
+state from previous flights."
+```
+
+---
+
+## Task 6: Full Test Suite Verification + Lint
+
+**Files:**
+- No file modifications
+
+- [ ] **Step 1: Run full tello-mcp test suite**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/ -v`
+
+Expected: All tests PASS. Count should be 150 (existing) + new tests = ~165+.
+
+- [ ] **Step 2: Run lint and format checks**
+
+Run: `uv run ruff check services/tello-mcp/ && uv run ruff format --check services/tello-mcp/`
+
+Expected: Clean — no errors.
+
+- [ ] **Step 3: Run all workspace tests (regression check)**
+
+Run each package separately per CLAUDE.md conventions:
+
+```bash
+uv run --package tello-core pytest packages/tello-core/tests/ -v
+uv run --package tello-navigator pytest services/tello-navigator/tests/ -v
+uv run --package tello-telemetry pytest services/tello-telemetry/tests/ -v
+```
+
+Expected: All pass. No regressions in other packages.
+
+- [ ] **Step 4: Commit any lint fixes if needed**
+
+If ruff found issues:
+```bash
+uv run ruff check --fix services/tello-mcp/
+uv run ruff format services/tello-mcp/
+git add -u && git commit -m "style: fix lint issues from Phase 4c changes"
+```
+
+---
+
+## Task 7: Update Memory + Spec + PR
+
+**Files:**
+- Modify: `~/.claude/projects/-Users-arthurfantaci-Projects-tello-ai-platform/memory/MEMORY.md`
+- Include: `docs/superpowers/specs/2026-03-20-phase4c-obstacle-monitor-bugfixes-design.md`
+- Include: `docs/superpowers/plans/2026-03-20-phase4c-obstacle-monitor-bugfixes.md`
+
+- [ ] **Step 1: Add spec + plan to the commit**
+
+The spec and plan files are currently untracked. Stage them:
+```bash
+git add docs/superpowers/specs/2026-03-20-phase4c-obstacle-monitor-bugfixes-design.md
+git add docs/superpowers/plans/2026-03-20-phase4c-obstacle-monitor-bugfixes.md
+git commit -m "docs: Phase 4c spec + implementation plan"
+```
+
+- [ ] **Step 2: Push branch and create PR**
+
+```bash
+git push -u origin feat/phase-4c-obstacle-monitor-bugfixes
+```
+
+Create PR with:
+- Title: `fix: Phase 4c — ObstacleMonitor bug fixes + observability`
+- Body: Summary of three bugs fixed, testing approach, link to spec
+- Must include `Closes #N` for the GitHub issue
+
+- [ ] **Step 3: Wait for CI**
+
+Run: `gh pr checks <PR_NUMBER>`
+
+Expected: All checks pass (lint + 4 test suites). Type-check advisory only.
+
+- [ ] **Step 4: Update MEMORY.md with Phase 4c status**
+
+Update current state in MEMORY.md:
+- Phase: 4c implementation complete, PR open, CI pending
+- Tests: updated count
+- Next action: physical test after merge, then Phase 4d
+
+---
+
+## Task 8: Physical Test (Post-Merge Validation)
+
+> **Prerequisites:** PR merged, branch cleaned, on `main`.
+> **Requires:** Drone powered on, human present.
+
+- [ ] **Step 1: Claude Code starts infrastructure and services**
+
+1. Verify Docker: `docker compose ps` (Neo4j + Redis healthy)
+2. Kill any stale tello-telemetry: `kill $(lsof -iTCP:8200 -sTCP:LISTEN -t) 2>/dev/null`
+3. Clear Redis stream: `docker exec tello-ai-platform-redis-1 redis-cli XTRIM tello:events MAXLEN 0`
+4. Start tello-telemetry: `export $(grep -v '^#' .env | xargs) && uv run --package tello-telemetry python -m tello_telemetry.server --transport streamable-http --port 8200 &`
+5. Verify tello-mcp connected: `get_telemetry` MCP tool
+6. Record baseline: Neo4j FlightSession count, ObstacleIncident count, Redis stream length
+
+- [ ] **Step 2: Ask human to confirm drone ready**
+
+"Is the drone positioned facing a wall with ~1m of forward space?"
+
+- [ ] **Step 3: Execute flight**
+
+1. `takeoff(room_id="living-room")`
+2. `move(direction="forward", distance_cm=50)` — may return "Motor stop" (expected)
+3. Wait for RTH to complete: `get_telemetry` until `height_cm == 0`
+
+- [ ] **Step 4: Post-flight validation**
+
+1. Wait 30 seconds, check Redis XLEN at 0s, 15s, 30s
+2. **Pass:** Stream count == 3 (takeoff + obstacle_danger + land), stable over 30s
+3. Query Neo4j: `MATCH (fs:FlightSession) WHERE fs.end_time IS NOT NULL RETURN fs ORDER BY fs.start_time DESC LIMIT 1`
+4. Query Neo4j: `MATCH (o:ObstacleIncident)-[:TRIGGERED_DURING]->(fs:FlightSession) RETURN o, fs ORDER BY o.timestamp DESC LIMIT 1`
+5. **Pass:** FlightSession has `end_time`, ObstacleIncident linked via TRIGGERED_DURING
+
+- [ ] **Step 5: Report results and update MEMORY.md**
+
+If PASS: Update MEMORY.md — Phase 4c COMPLETE, update test counts, note pipeline validated.
+If FAIL: Investigate using the new structured logs, iterate on fix.

--- a/docs/superpowers/specs/2026-03-20-phase4c-obstacle-monitor-bugfixes-design.md
+++ b/docs/superpowers/specs/2026-03-20-phase4c-obstacle-monitor-bugfixes-design.md
@@ -1,0 +1,276 @@
+# Phase 4c: ObstacleMonitor Bug Fixes + Observability
+
+**Date:** 2026-03-20
+**Phase:** 4c
+**Status:** Approved
+**Depends on:** Phase 4b (merged, PR #23)
+
+## Problem Statement
+
+End-to-end pipeline testing (2026-03-19 and 2026-03-20) revealed three bugs in the obstacle avoidance event-publishing chain. The drone's physical safety behavior is correct (RTH stops, reverses, and lands reliably), but the software's reporting of those actions to the data pipeline is broken in two distinct failure modes:
+
+### Bug #1: Missing RTH Events (Confirmed Reproducible — Runs 2 & 3)
+
+**Symptom:** ObstacleMonitor triggers RTH, drone physically reverses and lands, but `obstacle_danger` and `land` events are never published to Redis. FlightSession is never closed (no `end_time`). No ObstacleIncident in Neo4j.
+
+**Root cause hypothesis:** An unhandled exception in the `on_obstacle_reading` callback silently kills event publishing. The `_poll_loop` (obstacle.py lines 176-179) has no `try/except` around callback execution — any exception propagates and either kills the callback chain or is swallowed without logging.
+
+**Evidence:** Redis stream shows only `takeoff` event after flights where RTH clearly executed (drone observed reversing and landing). No structured logs available to diagnose further — the failure is completely silent.
+
+### Bug #2: Post-Landing Infinite DANGER Loop (Run 1, Position-Dependent)
+
+**Symptom:** After RTH lands the drone near an obstacle (<200mm), ObstacleMonitor continues polling, sees DANGER, re-triggers RTH on a grounded drone. Produces ~1 `obstacle_danger` + `land` event pair per second indefinitely. Run 1 produced 280 events (140 pairs) before the session was stopped.
+
+**Root cause:** `on_obstacle_reading` has no guard for "drone is already on the ground" or "RTH is already in progress." After landing, if the forward ToF sensor still reads <200mm (drone landed close to obstacle), the callback fires RTH again on a grounded drone.
+
+**Condition:** Only occurs when the drone's final position after RTH reverse is still within DANGER range (<200mm from obstacle). Run 1: drone landed at ~185mm (DANGER). Runs 2-3: drone landed at ~700mm (CLEAR) — no loop.
+
+**Mitigating factor:** The tello-telemetry consumer's `_handle_land()` sets `_current_session = None`, causing subsequent `obstacle_danger` events to be silently dropped (no active session guard). This accidentally prevented Neo4j spam — only 1 ObstacleIncident was written despite 140 DANGER events.
+
+### Bug #3: Orphaned FlightSessions on Failed Takeoff
+
+**Symptom:** `publish_event("takeoff")` fires before checking if the SDK `takeoff()` command succeeded. When the SDK times out or fails, a FlightSession is created in Neo4j with no matching `land` event — an orphaned session with no `end_time`.
+
+**Evidence:** Three orphaned FlightSessions found in Neo4j (cleaned up during testing): one from integration test, one from failed connection attempt, one from SDK timeout.
+
+**Root cause:** In `flight.py`, the takeoff tool publishes the event unconditionally:
+```python
+result = await queue.enqueue(drone.takeoff, heavy=True)
+await telemetry.publish_event("takeoff", {"room_id": room_id})  # fires regardless of result
+return result
+```
+
+## Design
+
+### Fix #1: Callback Exception Handling in `_poll_loop`
+
+Wrap callback execution in `obstacle.py` `_poll_loop` with `try/except`:
+
+```python
+for cb in self._callbacks:
+    try:
+        cb_result = cb(reading)
+        if asyncio.iscoroutine(cb_result):
+            await cb_result
+    except Exception:
+        logger.exception("obstacle.callback_failed", distance_mm=reading.distance_mm, zone=reading.zone.value)
+```
+
+This ensures:
+- The monitor keeps running after a callback failure
+- The failure is logged with full traceback for diagnosis
+- Subsequent callbacks still execute even if one fails
+
+### Fix #2: RTH Guards in `ObstacleResponseHandler`
+
+Add two guards to `on_obstacle_reading`:
+
+**Guard A — RTH-in-progress flag:**
+```python
+# In __init__:
+self._rth_active = False
+
+# In on_obstacle_reading:
+if self._rth_active:
+    logger.debug("obstacle.rth_skipped_active", distance_mm=reading.distance_mm)
+    return
+```
+
+**Guard B — Grounded check (only when height query succeeds):**
+```python
+height_result = await asyncio.to_thread(self._drone.get_height)
+height_cm = height_result.get("height_cm", 0) if height_result.get("status") == "ok" else 0
+
+# Only skip RTH if we have a confirmed ground reading — a failed get_height
+# must NOT suppress RTH, as the drone may be airborne with a sensor error.
+if height_result.get("status") == "ok" and height_cm == 0:
+    logger.debug("obstacle.rth_skipped_grounded", height_cm=height_cm, distance_mm=reading.distance_mm)
+    return
+```
+
+**Flag lifecycle:**
+```python
+self._rth_active = True
+try:
+    context = ObstacleContext(...)
+    await self.execute(ObstacleResponse.RETURN_TO_HOME, context)
+finally:
+    self._rth_active = False
+```
+
+The `finally` block ensures the flag is always cleared, even if `execute()` raises.
+
+### Fix #3: Publish-After-Success in Flight Tools
+
+**Note on dual `land` event paths:** There are two independent paths that publish
+`land` events: (1) the `land` MCP tool in flight.py (manual landing) and (2)
+`ObstacleResponseHandler.execute()` in obstacle.py (automated RTH landing). These
+are mutually exclusive — manual landing goes through the tool, RTH landing goes
+through the handler. Both paths should gate on success, but they cannot produce
+duplicate events for the same landing.
+
+**takeoff:**
+
+```python
+result = await queue.enqueue(drone.takeoff, heavy=True)
+if result.get("status") == "ok":
+    await telemetry.publish_event("takeoff", {"room_id": room_id})
+else:
+    logger.warning("event.skipped_command_failed",
+                   event_type="takeoff", error=result.get("error"))
+return result
+```
+
+**land:**
+
+```python
+result = await queue.enqueue(drone.safe_land)
+if result.get("status") == "ok":
+    await telemetry.publish_event("land", {})
+else:
+    logger.warning("event.skipped_command_failed",
+                   event_type="land", error=result.get("error"))
+return result
+```
+
+### Observability: Structured Log Events
+
+Add structured log events at key decision points:
+
+| Log Event | Logger | Trigger | Key Fields |
+|---|---|---|---|
+| `obstacle.callback_failed` | `tello_mcp.obstacle` | Callback raises exception | `error`, `distance_mm`, `zone` |
+| `obstacle.rth_skipped_grounded` | `tello_mcp.obstacle` | Height guard fires | `height_cm`, `distance_mm` |
+| `obstacle.rth_skipped_active` | `tello_mcp.obstacle` | RTH-in-progress guard fires | `distance_mm` |
+| `obstacle.rth_started` | `tello_mcp.obstacle` | RTH begins executing | `distance_mm`, `height_cm`, `last_direction` |
+| `obstacle.rth_completed` | `tello_mcp.obstacle` | RTH finishes | `outcome`, `reversed_direction` |
+| `event.published` | `tello_mcp.telemetry` | Event added to Redis | `event_type` |
+| `event.publish_failed` | `tello_mcp.telemetry` | Redis XADD fails | `event_type`, `error` |
+| `event.skipped_command_failed` | `tello_mcp.tools` | Event skipped (SDK failure) | `event_type`, `error` |
+
+### Observability: TelemetryPublisher Error Handling
+
+Wrap `xadd` in `publish_event` with try/except to surface Redis failures:
+
+```python
+async def publish_event(self, event_type: str, data: dict[str, Any]) -> None:
+    fields = {"event_type": event_type, **{k: str(v) for k, v in data.items()}}
+    try:
+        await self._redis.xadd(self._stream, fields)
+        logger.info("event.published", event_type=event_type)
+    except Exception:
+        logger.exception("event.publish_failed", event_type=event_type)
+```
+
+### Observability: Status Methods
+
+**ObstacleMonitor.status():**
+
+```python
+def status(self) -> dict:
+    return {
+        "running": self._running,
+        "in_danger": self._in_danger,
+        "danger_clear_count": self._danger_clear_count,
+        "latest_reading_mm": self._latest.distance_mm if self._latest else None,
+        "latest_zone": self._latest.zone.value if self._latest else None,
+    }
+```
+
+**ObstacleResponseHandler.status():**
+
+```python
+def status(self) -> dict:
+    return {"rth_active": self._rth_active}
+```
+
+### Observability: State Reset on Monitor Start
+
+When the monitor starts (or restarts between flights), reset internal state
+to prevent stale values from a previous flight leaking into the next one:
+
+```python
+async def start(self) -> None:
+    if self._running:
+        return
+    self._in_danger = False
+    self._danger_clear_count = 0
+    self._running = True
+    self._task = asyncio.create_task(self._poll_loop())
+```
+
+## Testing
+
+### Unit Tests
+
+**callback exception handling:**
+- `_poll_loop` continues after callback raises `RuntimeError`
+- Exception is logged (verify with structlog `capture_logs()`)
+
+**RTH guards:**
+- `on_obstacle_reading` returns immediately when `_rth_active` is True
+- `on_obstacle_reading` returns immediately when `height_cm == 0`
+- `_rth_active` is set to True before `execute()` and False after
+- `_rth_active` is cleared even if `execute()` raises
+
+**Publish-after-success:**
+- `takeoff` tool does NOT call `publish_event` when SDK returns error
+- `land` tool does NOT call `publish_event` when SDK returns error
+- `takeoff` tool calls `publish_event` when SDK returns success
+- `land` tool calls `publish_event` when SDK returns success
+
+**Status methods:**
+- `ObstacleMonitor.status()` returns correct fields
+- `ObstacleResponseHandler.status()` returns `rth_active` state
+
+### Physical Test (End-to-End Pipeline Validation)
+
+**Pre-flight (Claude Code automates):**
+1. Verify Docker infrastructure (Neo4j + Redis) running and healthy
+2. Start tello-telemetry in background
+3. Verify tello-mcp connected to drone via `get_telemetry`
+4. Record Redis stream baseline count
+5. Record Neo4j FlightSession and ObstacleIncident counts
+
+**Flight (Claude Code via MCP, human confirms drone ready):**
+1. Ask human: "Is the drone positioned facing a wall with ~1m of forward space?"
+2. `takeoff(room_id="living-room")`
+3. `move(direction="forward", distance_cm=50)` — may return "Motor stop" (expected)
+4. Wait for RTH to complete (check height == 0)
+
+**Post-flight validation (Claude Code automates):**
+1. Wait 30 seconds, check Redis stream count at 0s, 15s, 30s
+2. Stream count should be exactly 3 (takeoff + obstacle_danger + land)
+3. Stream count should NOT grow over 30 seconds (no infinite loop)
+4. Query Neo4j: new FlightSession has `end_time` set
+5. Query Neo4j: new ObstacleIncident exists with `TRIGGERED_DURING` relationship
+6. Report pass/fail with full data
+
+**Pass criteria:**
+- Redis: exactly 3 events, stable count for 30s
+- Neo4j: FlightSession closed, ObstacleIncident linked
+- No orphaned sessions from this test run
+
+## Files Modified
+
+- `services/tello-mcp/src/tello_mcp/obstacle.py` — callback guard, RTH guards, status methods, structured logging
+- `services/tello-mcp/src/tello_mcp/tools/flight.py` — publish-after-success for takeoff and land
+- `services/tello-mcp/src/tello_mcp/telemetry.py` — publish error logging
+- `services/tello-mcp/tests/test_obstacle.py` — callback exception test, RTH guard tests, status tests
+- `services/tello-mcp/tests/test_tools/test_flight.py` — publish-on-failure tests
+
+## Out of Scope
+
+- **Phase 4d:** Containerization, Docker Compose orchestration, health check endpoints
+- **Phase 4e:** Unified Command Path (architectural refactor before Phase 5)
+- New MCP tools for status (status methods are internal; exposure deferred)
+- Log aggregation, dashboards, metrics (overkill for current scale)
+- tello-telemetry consumer hardening (its "no active session" guard already works)
+
+## Phase Sequencing
+
+- **Phase 4c** (this spec): Bug fixes + observability
+- **Phase 4d**: Containerize tello-mcp and tello-telemetry, Docker Compose as single startup, HTTP MCP transport
+- **Phase 4e**: Unify CommandQueue + ObstacleMonitor into single command coordination layer (required before Phase 5 adds vision-based obstacle detection as a third actor)
+- **Phase 5**: tello-vision (CV pipeline)
+- **Phase 6**: tello-voice (NL controller + AI agent with MCP client)

--- a/services/tello-mcp/src/tello_mcp/obstacle.py
+++ b/services/tello-mcp/src/tello_mcp/obstacle.py
@@ -115,6 +115,16 @@ class ObstacleMonitor:
         """Whether the monitor is actively polling."""
         return self._running
 
+    def status(self) -> dict:
+        """Current monitor state for diagnostics."""
+        return {
+            "running": self._running,
+            "in_danger": self._in_danger,
+            "danger_clear_count": self._danger_clear_count,
+            "latest_reading_mm": self._latest.distance_mm if self._latest else None,
+            "latest_zone": self._latest.zone.value if self._latest else None,
+        }
+
     def on_reading(self, callback: Callable[[ObstacleReading], None | Awaitable[None]]) -> None:
         """Subscribe to obstacle readings."""
         self._callbacks.append(callback)
@@ -123,6 +133,8 @@ class ObstacleMonitor:
         """Start the background polling loop. Idempotent."""
         if self._running:
             return
+        self._in_danger = False
+        self._danger_clear_count = 0
         self._running = True
         self._task = asyncio.create_task(self._poll_loop())
         logger.info("obstacle_monitor.started", poll_interval_ms=self._config.poll_interval_ms)
@@ -216,6 +228,10 @@ class ObstacleResponseHandler:
         self._telemetry = telemetry
         self._last_command = last_command
         self._rth_active = False
+
+    def status(self) -> dict:
+        """Current handler state for diagnostics."""
+        return {"rth_active": self._rth_active}
 
     async def execute(
         self,

--- a/services/tello-mcp/src/tello_mcp/obstacle.py
+++ b/services/tello-mcp/src/tello_mcp/obstacle.py
@@ -174,9 +174,16 @@ class ObstacleMonitor:
                 self._latest = reading
 
                 for cb in self._callbacks:
-                    cb_result = cb(reading)
-                    if asyncio.iscoroutine(cb_result):
-                        await cb_result
+                    try:
+                        cb_result = cb(reading)
+                        if asyncio.iscoroutine(cb_result):
+                            await cb_result
+                    except Exception:
+                        logger.exception(
+                            "obstacle.callback_failed",
+                            distance_mm=reading.distance_mm,
+                            zone=reading.zone.value,
+                        )
 
             await asyncio.sleep(self._config.poll_interval_ms / 1000)
 

--- a/services/tello-mcp/src/tello_mcp/obstacle.py
+++ b/services/tello-mcp/src/tello_mcp/obstacle.py
@@ -215,6 +215,7 @@ class ObstacleResponseHandler:
         self._rth = rth_strategy
         self._telemetry = telemetry
         self._last_command = last_command
+        self._rth_active = False
 
     async def execute(
         self,
@@ -263,25 +264,55 @@ class ObstacleResponseHandler:
     async def on_obstacle_reading(self, reading: ObstacleReading) -> None:
         """Callback for ObstacleMonitor — auto-triggers RTH on DANGER.
 
-        Registered via monitor.on_reading(handler.on_obstacle_reading).
-        Builds ObstacleContext from lifespan state and dispatches to execute().
+        Guards:
+        - Ignores non-DANGER readings
+        - Skips if RTH is already in progress (_rth_active flag)
+        - Skips if drone is confirmed on the ground (height_cm == 0)
+        - Does NOT skip if get_height fails (drone may be airborne)
         """
         if reading.zone != ObstacleZone.DANGER:
+            return
+
+        if self._rth_active:
+            logger.debug("obstacle.rth_skipped_active", distance_mm=reading.distance_mm)
             return
 
         last_cmd = self._last_command or {}
         height_result = await asyncio.to_thread(self._drone.get_height)
         height_cm = height_result.get("height_cm", 0) if height_result.get("status") == "ok" else 0
 
-        context = ObstacleContext(
-            last_direction=last_cmd.get("direction", ""),
-            last_distance_cm=int(last_cmd.get("distance_cm", 0)),
-            height_cm=height_cm,
-            forward_distance_mm=reading.distance_mm,
-            mission_id=last_cmd.get("mission_id"),
-            room_id=last_cmd.get("room_id"),
-        )
-        await self.execute(ObstacleResponse.RETURN_TO_HOME, context)
+        if height_result.get("status") == "ok" and height_cm == 0:
+            logger.debug(
+                "obstacle.rth_skipped_grounded",
+                height_cm=height_cm,
+                distance_mm=reading.distance_mm,
+            )
+            return
+
+        self._rth_active = True
+        try:
+            logger.info(
+                "obstacle.rth_started",
+                distance_mm=reading.distance_mm,
+                height_cm=height_cm,
+                last_direction=last_cmd.get("direction", ""),
+            )
+            context = ObstacleContext(
+                last_direction=last_cmd.get("direction", ""),
+                last_distance_cm=int(last_cmd.get("distance_cm", 0)),
+                height_cm=height_cm,
+                forward_distance_mm=reading.distance_mm,
+                mission_id=last_cmd.get("mission_id"),
+                room_id=last_cmd.get("room_id"),
+            )
+            result = await self.execute(ObstacleResponse.RETURN_TO_HOME, context)
+            logger.info(
+                "obstacle.rth_completed",
+                outcome=result.get("status", "unknown"),
+                reversed_direction=result.get("reversed_direction"),
+            )
+        finally:
+            self._rth_active = False
 
 
 @runtime_checkable

--- a/services/tello-mcp/src/tello_mcp/telemetry.py
+++ b/services/tello-mcp/src/tello_mcp/telemetry.py
@@ -52,5 +52,8 @@ class TelemetryPublisher:
             data: Event payload.
         """
         fields = {"event_type": event_type, **{k: str(v) for k, v in data.items()}}
-        await self._redis.xadd(self._stream, fields)
-        logger.info("Published event %s", event_type)
+        try:
+            await self._redis.xadd(self._stream, fields)
+            logger.info("event.published", event_type=event_type)
+        except Exception:
+            logger.exception("event.publish_failed", event_type=event_type)

--- a/services/tello-mcp/src/tello_mcp/tools/flight.py
+++ b/services/tello-mcp/src/tello_mcp/tools/flight.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import structlog
 from fastmcp import Context
 from mcp.types import ToolAnnotations
+
+logger = structlog.get_logger("tello_mcp.tools.flight")
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -25,7 +28,14 @@ def register(mcp: FastMCP) -> None:
         queue = ctx.lifespan_context["queue"]
         telemetry = ctx.lifespan_context["telemetry"]
         result = await queue.enqueue(drone.takeoff, heavy=True)
-        await telemetry.publish_event("takeoff", {"room_id": room_id})
+        if result.get("status") == "ok":
+            await telemetry.publish_event("takeoff", {"room_id": room_id})
+        else:
+            logger.warning(
+                "event.skipped_command_failed",
+                event_type="takeoff",
+                error=result.get("error"),
+            )
         return result
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False))
@@ -35,7 +45,14 @@ def register(mcp: FastMCP) -> None:
         queue = ctx.lifespan_context["queue"]
         telemetry = ctx.lifespan_context["telemetry"]
         result = await queue.enqueue(drone.safe_land)
-        await telemetry.publish_event("land", {})
+        if result.get("status") == "ok":
+            await telemetry.publish_event("land", {})
+        else:
+            logger.warning(
+                "event.skipped_command_failed",
+                event_type="land",
+                error=result.get("error"),
+            )
         return result
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True))

--- a/services/tello-mcp/tests/test_obstacle.py
+++ b/services/tello-mcp/tests/test_obstacle.py
@@ -190,6 +190,46 @@ class TestObstacleMonitorPolling:
         assert len(readings) > 0
         assert readings[0].distance_mm == 600
 
+    async def test_callback_exception_does_not_kill_monitor(self):
+        """Poll loop survives a callback that raises an exception."""
+        drone = MagicMock()
+        drone.get_forward_distance.return_value = {"status": "ok", "distance_mm": 600}
+        config = ObstacleConfig(poll_interval_ms=50)
+        monitor = ObstacleMonitor(drone, config)
+
+        call_count = 0
+
+        def exploding_callback(reading):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                msg = "boom"
+                raise RuntimeError(msg)
+
+        monitor.on_reading(exploding_callback)
+        await monitor.start()
+        await asyncio.sleep(0.2)
+        await monitor.stop()
+        assert call_count >= 2
+
+    async def test_callback_exception_is_logged(self, capsys):
+        """Callback exception is logged for diagnosis."""
+        drone = MagicMock()
+        drone.get_forward_distance.return_value = {"status": "ok", "distance_mm": 600}
+        config = ObstacleConfig(poll_interval_ms=50)
+        monitor = ObstacleMonitor(drone, config)
+
+        def exploding_callback(reading):
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        monitor.on_reading(exploding_callback)
+        await monitor.start()
+        await asyncio.sleep(0.15)
+        await monitor.stop()
+        captured = capsys.readouterr()
+        assert "callback_failed" in captured.out or "boom" in captured.out
+
 
 class TestObstacleResponse:
     def test_response_values(self):

--- a/services/tello-mcp/tests/test_obstacle.py
+++ b/services/tello-mcp/tests/test_obstacle.py
@@ -570,3 +570,52 @@ class TestCLIResponseProvider:
         monkeypatch.setattr("builtins.input", lambda _: next(inputs))
         choice = await provider.present_options(reading)
         assert choice == ObstacleResponse.RETURN_TO_HOME
+
+
+class TestObstacleMonitorStatus:
+    def test_status_initial_state(self):
+        monitor = ObstacleMonitor(MagicMock())
+        status = monitor.status()
+        assert status == {
+            "running": False,
+            "in_danger": False,
+            "danger_clear_count": 0,
+            "latest_reading_mm": None,
+            "latest_zone": None,
+        }
+
+    async def test_status_after_start(self):
+        drone = MagicMock()
+        drone.get_forward_distance.return_value = {"status": "ok", "distance_mm": 600}
+        config = ObstacleConfig(poll_interval_ms=50)
+        monitor = ObstacleMonitor(drone, config)
+        await monitor.start()
+        await asyncio.sleep(0.1)
+        status = monitor.status()
+        assert status["running"] is True
+        assert status["latest_reading_mm"] == 600
+        assert status["latest_zone"] == "clear"
+        await monitor.stop()
+
+    async def test_start_resets_stale_state(self):
+        """Starting the monitor resets _in_danger and _danger_clear_count."""
+        drone = MagicMock()
+        drone.get_forward_distance.return_value = {"error": "EXHAUSTED"}
+        monitor = ObstacleMonitor(drone, ObstacleConfig(poll_interval_ms=50))
+        monitor._in_danger = True
+        monitor._danger_clear_count = 2
+        await monitor.start()
+        assert monitor._in_danger is False
+        assert monitor._danger_clear_count == 0
+        await monitor.stop()
+
+
+class TestObstacleResponseHandlerStatus:
+    def test_status_initial(self):
+        handler = ObstacleResponseHandler(MagicMock())
+        assert handler.status() == {"rth_active": False}
+
+    def test_status_rth_active(self):
+        handler = ObstacleResponseHandler(MagicMock())
+        handler._rth_active = True
+        assert handler.status() == {"rth_active": True}

--- a/services/tello-mcp/tests/test_obstacle.py
+++ b/services/tello-mcp/tests/test_obstacle.py
@@ -433,6 +433,109 @@ class TestObstacleMonitorDebounce:
         assert all(z == ObstacleZone.DANGER for z in zones)
 
 
+class TestRTHGuards:
+    """Tests for on_obstacle_reading guards that prevent re-entry and grounded RTH."""
+
+    def _make_handler(self):
+        drone = MagicMock()
+        drone.safe_land.return_value = {"status": "ok"}
+        strategy = MagicMock()
+        strategy.return_to_home.return_value = {
+            "status": "returned",
+            "method": "simple_reverse",
+            "reversed_direction": "back",
+            "height_cm": 80,
+            "forward_distance_mm": 185,
+            "landed": True,
+        }
+        telemetry = AsyncMock()
+        telemetry.publish_event = AsyncMock()
+        handler = ObstacleResponseHandler(
+            drone=drone,
+            rth_strategy=strategy,
+            telemetry=telemetry,
+            last_command={"direction": "forward", "distance_cm": 50},
+        )
+        return handler, drone, strategy, telemetry
+
+    async def test_rth_skipped_when_active(self):
+        """on_obstacle_reading returns immediately if RTH is already in progress."""
+        handler, _drone, strategy, _tel = self._make_handler()
+        handler._rth_active = True
+
+        reading = ObstacleReading(
+            distance_mm=185,
+            zone=ObstacleZone.DANGER,
+            timestamp=datetime(2026, 3, 20),
+        )
+        await handler.on_obstacle_reading(reading)
+        strategy.return_to_home.assert_not_called()
+
+    async def test_rth_skipped_when_grounded(self):
+        """on_obstacle_reading returns immediately if drone is on the ground."""
+        handler, drone, strategy, _tel = self._make_handler()
+        drone.get_height.return_value = {"status": "ok", "height_cm": 0}
+
+        reading = ObstacleReading(
+            distance_mm=185,
+            zone=ObstacleZone.DANGER,
+            timestamp=datetime(2026, 3, 20),
+        )
+        await handler.on_obstacle_reading(reading)
+        strategy.return_to_home.assert_not_called()
+
+    async def test_rth_not_skipped_when_height_query_fails(self):
+        """A failed get_height must NOT suppress RTH — drone may be airborne."""
+        handler, drone, strategy, _tel = self._make_handler()
+        drone.get_height.return_value = {"error": "HEIGHT_FAILED", "detail": "timeout"}
+
+        reading = ObstacleReading(
+            distance_mm=185,
+            zone=ObstacleZone.DANGER,
+            timestamp=datetime(2026, 3, 20),
+        )
+        await handler.on_obstacle_reading(reading)
+        strategy.return_to_home.assert_called_once()
+
+    async def test_rth_active_flag_set_during_execution(self):
+        """_rth_active is True while execute() is running, False after."""
+        handler, drone, strategy, _tel = self._make_handler()
+        drone.get_height.return_value = {"status": "ok", "height_cm": 80}
+
+        observed_during: list[bool] = []
+        original_execute = handler.execute
+
+        async def spy_execute(*args, **kwargs):
+            observed_during.append(handler._rth_active)
+            return await original_execute(*args, **kwargs)
+
+        handler.execute = spy_execute
+
+        reading = ObstacleReading(
+            distance_mm=185,
+            zone=ObstacleZone.DANGER,
+            timestamp=datetime(2026, 3, 20),
+        )
+        await handler.on_obstacle_reading(reading)
+        assert observed_during == [True]
+        assert handler._rth_active is False
+
+    async def test_rth_active_flag_cleared_on_exception(self):
+        """_rth_active is cleared even if execute() raises."""
+        handler, drone, _strategy, _tel = self._make_handler()
+        drone.get_height.return_value = {"status": "ok", "height_cm": 80}
+        handler.execute = AsyncMock(side_effect=RuntimeError("execute failed"))
+
+        reading = ObstacleReading(
+            distance_mm=185,
+            zone=ObstacleZone.DANGER,
+            timestamp=datetime(2026, 3, 20),
+        )
+        with pytest.raises(RuntimeError, match="execute failed"):
+            await handler.on_obstacle_reading(reading)
+        assert handler._rth_active is False
+
+
 class TestCLIResponseProvider:
     async def test_present_options_emergency_land(self, monkeypatch):
         provider = CLIResponseProvider()

--- a/services/tello-mcp/tests/test_telemetry.py
+++ b/services/tello-mcp/tests/test_telemetry.py
@@ -1,6 +1,7 @@
 """Tests for the telemetry publisher."""
 
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -57,3 +58,14 @@ class TestTelemetryPublisher:
         call_args = mock_redis.xadd.call_args
         fields = call_args[0][1]
         assert fields["event_type"] == "takeoff"
+
+    async def test_publish_event_logs_redis_failure(self, mock_redis):
+        """Redis xadd failure is caught and logged, not raised."""
+        mock_redis.xadd = AsyncMock(side_effect=ConnectionError("Redis down"))
+        publisher = TelemetryPublisher(
+            redis_client=mock_redis,
+            channel="tello:telemetry",
+            stream="tello:events",
+        )
+        # Should not raise
+        await publisher.publish_event("takeoff", {"room_id": "test"})

--- a/services/tello-mcp/tests/test_tools/test_flight.py
+++ b/services/tello-mcp/tests/test_tools/test_flight.py
@@ -87,3 +87,33 @@ class TestFlightTools:
         call_args = mock_telemetry.publish_event.call_args
         assert call_args[0][0] == "takeoff"
         assert call_args[0][1]["room_id"] == "living_room"
+
+    async def test_takeoff_does_not_publish_on_failure(self):
+        """Takeoff event is NOT published when SDK command fails."""
+        mock_queue = AsyncMock()
+        mock_queue.enqueue = AsyncMock(
+            return_value={"error": "COMMAND_FAILED", "detail": "timeout"}
+        )
+        mock_telemetry = AsyncMock()
+        ctx = self._make_ctx(queue=mock_queue, telemetry=mock_telemetry)
+        await self.registered_tools["takeoff"](ctx, room_id="living-room")
+        mock_telemetry.publish_event.assert_not_called()
+
+    async def test_land_does_not_publish_on_failure(self):
+        """Land event is NOT published when SDK command fails."""
+        mock_queue = AsyncMock()
+        mock_queue.enqueue = AsyncMock(return_value={"error": "LAND_FAILED", "detail": "timeout"})
+        mock_telemetry = AsyncMock()
+        ctx = self._make_ctx(queue=mock_queue, telemetry=mock_telemetry)
+        await self.registered_tools["land"](ctx)
+        mock_telemetry.publish_event.assert_not_called()
+
+    async def test_land_publishes_on_success(self):
+        """Land event IS published when SDK command succeeds."""
+        mock_queue = AsyncMock()
+        mock_queue.enqueue = AsyncMock(return_value={"status": "ok"})
+        mock_telemetry = AsyncMock()
+        ctx = self._make_ctx(queue=mock_queue, telemetry=mock_telemetry)
+        await self.registered_tools["land"](ctx)
+        mock_telemetry.publish_event.assert_called_once()
+        assert mock_telemetry.publish_event.call_args[0][0] == "land"


### PR DESCRIPTION
## Summary

- **Bug #1 fix:** Callback exception handling in `_poll_loop` — prevents silent monitor death when RTH event publishing fails
- **Bug #2 fix:** RTH guards (`_rth_active` flag + grounded check) — prevents post-landing infinite DANGER loop and duplicate RTH
- **Bug #3 fix:** Publish-after-success in flight tools — prevents orphaned FlightSessions on SDK failure
- **TelemetryPublisher error handling** — catches Redis `xadd` failures instead of propagating
- **Observability:** 8 structured log events at all RTH decision points + `status()` methods on ObstacleMonitor and ObstacleResponseHandler + state reset on monitor start

Closes #24

## Test Plan

- [x] 16 new unit tests (166 total tello-mcp, 334 total workspace)
- [x] Lint + format clean
- [x] No regressions in tello-core (65), tello-navigator (54), tello-telemetry (49)
- [ ] Physical test: end-to-end pipeline validation (post-merge)

## Spec

`docs/superpowers/specs/2026-03-20-phase4c-obstacle-monitor-bugfixes-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)