### PR TITLE
feat: Phase 4d — containerize tello-telemetry + HTTP transport (#26)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git/
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+.claude/
+docs/
+.env
+.mcp.json
+.ruff_cache/
+.pytest_cache/
+*.egg-info/
+**/tests/
+**/test_*/
+.gitignore
+*.md
+LICENSE

--- a/.mcp.json
+++ b/.mcp.json
@@ -21,10 +21,12 @@
       }
     },
     "tello-mcp": {
-      "type": "stdio",
-      "command": "uv",
-      "args": ["run", "--package", "tello-mcp", "python", "-m", "tello_mcp.server"],
-      "cwd": "."
+      "type": "http",
+      "url": "http://localhost:8100/mcp"
+    },
+    "tello-telemetry": {
+      "type": "http",
+      "url": "http://localhost:8200/mcp"
     }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,28 @@ services:
       timeout: 5s
       retries: 5
 
+  tello-telemetry:
+    build:
+      context: .
+      dockerfile: services/tello-telemetry/Dockerfile
+    ports:
+      - "8200:8200"
+    env_file: .env
+    environment:
+      REDIS_URL: redis://redis:6379
+      NEO4J_URI: bolt://neo4j:7687
+    depends_on:
+      redis:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8200/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+
 volumes:
   neo4j_data:
   neo4j_logs:

--- a/docs/phase4d-physical-test-report.md
+++ b/docs/phase4d-physical-test-report.md
@@ -1,0 +1,212 @@
+# Phase 4d Physical Flight Test Report
+
+**Date:** 2026-03-21 ~14:36 UTC
+**Branch:** `worktree-phase-4d-containerization`
+**Tester:** Claude Code (automated via MCP tools)
+
+## Test Setup
+
+- **Docker Compose stack running:** Neo4j (containerized, port 7474/7687) + Redis (containerized, port 6379) + tello-telemetry (containerized, port 8200)
+- **tello-mcp:** Running locally (HTTP transport, port 8100) — not containerized due to Docker Desktop macOS UDP limitation
+- **Drone:** RoboMaster TT, Router Mode, DHCP reservation at 192.168.68.102
+- **Battery at start:** 89%
+
+## Test Sequence (Timestamped)
+
+### 1. Connect — 14:36:16 UTC
+
+- `connect_drone` → `{"status": "already_connected"}` (tello-mcp was already running)
+- Pre-flight telemetry confirmed:
+  - Battery: 89%, Height: 0cm, ToF: 10cm (ground), Forward ToF: 1006mm (~1m to wall ahead)
+  - Temp: 62°C, Yaw: -11°
+
+### 2. Takeoff — 14:36:25 UTC
+
+- `takeoff(room_id="living_room")` → `{"status": "ok"}`
+- Post-takeoff telemetry: Height 60cm, Forward ToF 1081mm, zone CLEAR
+- **tello-telemetry container log:** `Created flight session bccdf597-4357-4bdc-aea8-b5a80c66c4cd`
+
+### 3. Forward Move Command — 14:36:~30 UTC
+
+- `move(direction="forward", distance_cm=100)` — intended to fly toward wall to trigger ObstacleMonitor RTH
+- **Result:** `{"error": "COMMAND_FAILED", "detail": "Command 'forward 100' was unsuccessful for 4 tries. Latest response: 'error Motor stop'"}`
+- **User report:** Drone crashed straight into the wall
+
+### 4. Post-Crash State — 14:36:41 UTC
+
+- Telemetry: Height 0cm (on ground), Forward ToF 575mm, Battery 83%, Yaw -84° (rotated ~70° during crash)
+- Obstacle status: zone CLEAR at 575mm (already past the wall, now further away after bounce/fall)
+
+### 5. Pipeline Events (from tello-telemetry container logs)
+
+| Timestamp | Event |
+|-----------|-------|
+| 14:36:26.113Z | `Created flight session bccdf597-4357-4bdc-aea8-b5a80c66c4cd` (room: living_room) |
+| 14:36:26.113Z | `Flight session started` |
+| 14:36:39.357Z | `Obstacle incident persisted` (id: 492b022c-...) |
+| 14:36:39.357Z | `Obstacle incident recorded` — distance: 136mm, response: RETURN_TO_HOME |
+| 14:36:39.450Z | `Ended flight session bccdf597-...` |
+| 14:36:39.450Z | `Flight session ended` |
+| 14:36:39.744Z | `Obstacle event without active session` (first of many repeated warnings) |
+| 14:36:39.745Z | `Land event without active session` |
+| 14:40:12–15Z | Continued spam of `Obstacle event without active session` + `Land event without active session` |
+
+## Neo4j Verification (Direct Cypher Queries)
+
+### FlightSession Node
+
+```
+{
+  id: "bccdf597-4357-4bdc-aea8-b5a80c66c4cd",
+  room_id: "living_room",
+  start_time: 2026-03-21T14:36:25.218263Z,
+  end_time: 2026-03-21T14:36:39.358097Z,
+  duration_s: 14,
+  anomaly_count: 0
+}
+```
+
+### ObstacleIncident Node
+
+```
+{
+  id: "492b022c-04ce-46a7-8c60-11cea3b73edd",
+  zone: "DANGER",
+  forward_distance_mm: 136,
+  forward_distance_in: 5.4,
+  height_cm: 10,
+  response: "RETURN_TO_HOME",
+  reversed_direction: "None",
+  outcome: "returned",
+  timestamp: 2026-03-21T14:36:39.122391Z
+}
+```
+
+### Relationship
+
+- `(ObstacleIncident)-[:TRIGGERED_DURING]->(FlightSession)` — **confirmed present**
+
+### TelemetrySample Nodes
+
+- Count: **0** — no telemetry samples were persisted (pre-existing issue, not 4d)
+
+## MCP Query Tool Issues
+
+### `list_flight_sessions` — BROKEN
+
+- Error: `Output validation error: outputSchema defined but no structured output returned`
+- Called twice, failed both times
+- **Root cause:** FastMCP outputSchema validation bug — the tool returns data but it doesn't match the declared schema
+
+### `get_flight_session(session_id=...)` — BROKEN
+
+- Same outputSchema validation error
+- Never returns data regardless of input
+
+### `get_session_anomalies(session_id=...)` — RETURNS EMPTY
+
+- Returns `{"anomalies": [], "count": 0}` even though ObstacleIncident exists
+- **Root cause:** Query looks for `o.distance_mm` but the Neo4j property is `o.forward_distance_mm`. Query looks up by `session_id` but the property is `id`.
+
+### `get_session_telemetry(session_id=...)` — RETURNS EMPTY
+
+- Returns `{"samples": [], "count": 0}`
+- Legitimate: 0 TelemetrySample nodes exist
+
+### `get_anomaly_summary` — RETURNS EMPTY
+
+- Returns `{"summary": []}`
+- **Root cause:** Queries `MATCH (a:Anomaly)` but the label is `ObstacleIncident`, not `Anomaly`. Neo4j warned: `The label 'Anomaly' does not exist`
+
+## Issues Found
+
+### Issue 1: Wall Crash — ObstacleMonitor Cannot Interrupt Blocking Moves
+
+- **Severity:** HIGH (safety)
+- **Category:** Pre-existing architectural limitation
+- **Description:** The `forward 100` SDK command is blocking — it holds the CommandQueue for the entire move duration. The ObstacleMonitor detected DANGER at 136mm and recorded the incident, but could not execute RTH because the move command was still in progress. The drone hit the wall.
+- **Evidence:** ObstacleIncident was persisted at 14:36:39 (136mm, RETURN_TO_HOME), but the crash had already occurred. The `height_cm: 10` on the incident suggests it was recorded after/during the crash (ground level), not during flight.
+- **Fix:** Phase 4e (Unified Command Path) — merge CommandQueue + ObstacleMonitor into a single coordination layer that can cancel in-progress moves.
+- **Workaround:** Use smaller move distances (20-30cm increments) so moves complete quickly enough for the monitor to intervene between commands.
+
+### Issue 2: MCP Query Tools — outputSchema Validation Failures
+
+- **Severity:** MEDIUM (query tools non-functional)
+- **Category:** New discovery (may be pre-existing but not previously tested via MCP)
+- **Affected tools:** `list_flight_sessions`, `get_flight_session`
+- **Error:** `Output validation error: outputSchema defined but no structured output returned`
+- **Likely cause:** FastMCP outputSchema was defined but the tool's return value doesn't conform to it, or the tool returns content in a format FastMCP doesn't recognize as structured output.
+
+### Issue 3: MCP Query Tools — Property Name Mismatches
+
+- **Severity:** MEDIUM (queries return wrong/empty data)
+- **Category:** Pre-existing bug
+- **Details:**
+  - `get_anomaly_summary` queries `MATCH (a:Anomaly)` but label is `ObstacleIncident`
+  - Queries reference `session_id` but Neo4j property is `id`
+  - Queries reference `distance_mm` but Neo4j property is `forward_distance_mm`
+
+### Issue 4: Post-Session Event Spam
+
+- **Severity:** LOW (log noise)
+- **Category:** Pre-existing (known from Phase 4c)
+- **Description:** After the session ends, the ObstacleMonitor continues firing events that arrive at tello-telemetry with no active session. These are logged as warnings and discarded. The spam continues for several seconds after landing.
+
+### Issue 5: `anomaly_count: 0` Despite ObstacleIncident
+
+- **Severity:** LOW (counter not incremented)
+- **Category:** Pre-existing bug
+- **Description:** The FlightSession node has `anomaly_count: 0` even though an ObstacleIncident is linked via TRIGGERED_DURING. The counter is not being incremented when obstacles are recorded.
+
+## Phase 4d Containerization Verdict
+
+### PASS — Containerization Works
+
+The core objective of Phase 4d was to containerize tello-telemetry and validate the data pipeline works through Docker. **This is confirmed:**
+
+| Pipeline Stage | Status |
+|---------------|--------|
+| tello-mcp → Redis XADD (takeoff event) | PASS |
+| tello-mcp → Redis XADD (obstacle event) | PASS |
+| tello-mcp → Redis XADD (land event) | PASS |
+| Containerized Redis receives events | PASS |
+| Containerized tello-telemetry XREADGROUP consumes events | PASS |
+| Containerized tello-telemetry creates FlightSession in Neo4j | PASS |
+| Containerized tello-telemetry creates ObstacleIncident in Neo4j | PASS |
+| Containerized tello-telemetry creates TRIGGERED_DURING relationship | PASS |
+| Containerized tello-telemetry sets end_time on session | PASS |
+| Health endpoint (`/health`) reports all dependencies up | PASS |
+| TelemetrySample persistence | NOT TESTED (0 samples — pre-existing) |
+
+### What Phase 4d Did NOT Break
+
+All issues found are pre-existing. The containerization did not introduce any regressions.
+
+## User Request: Containerize tello-mcp
+
+During the test, the user requested that tello-mcp also be containerized so all services are in the same Compose stack and runnable with `docker compose up`.
+
+### Context
+
+- The drone now has a **DHCP reservation** (static IP 192.168.68.102 via TP-Link Deco S4R)
+- Previously, containerizing tello-mcp was ruled out because Docker Desktop on macOS runs containers in a Linux VM that cannot reach the host's LAN via UDP (confirmed via ping test in earlier phase)
+- The DHCP reservation gives a stable IP but **does not solve the VM networking limitation**
+
+### Open Question
+
+The Docker Desktop macOS VM networking limitation still applies — a DHCP reservation alone doesn't fix container-to-LAN UDP connectivity. Options to investigate:
+
+1. **UDP proxy / socat forwarding** — run a host-side UDP forwarder that bridges container traffic to the drone
+2. **Docker Desktop `host.docker.internal`** — may allow TCP but UDP is uncertain
+3. **Docker socket mounting** — doesn't help with network
+4. **Run on Linux** — Docker on Linux supports `network_mode: host` which would work
+5. **Accept the limitation** — keep tello-mcp local, containerize everything else
+
+This needs research and a design decision before implementation.
+
+## Recommendations for Next Steps
+
+1. **Fix MCP query tools** — The outputSchema and property name mismatches make the query tools non-functional. This should be addressed before Phase 4d PR.
+2. **File Phase 4e issue** — The wall crash reinforces the urgency of the Unified Command Path to allow mid-move obstacle interruption.
+3. **Research tello-mcp containerization** — Investigate Docker Desktop macOS UDP forwarding options before committing to containerize tello-mcp.
+4. **Fix anomaly_count increment** — Minor bug, FlightSession.anomaly_count should reflect linked ObstacleIncidents.

--- a/docs/superpowers/plans/2026-03-20-phase4d-containerization.md
+++ b/docs/superpowers/plans/2026-03-20-phase4d-containerization.md
@@ -1,0 +1,673 @@
+# Phase 4d: Containerization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Containerize tello-telemetry in Docker Compose and switch both MCP services to HTTP transport, eliminating the manual multi-step startup that blocks physical testing.
+
+**Architecture:** tello-telemetry runs in Docker alongside Neo4j and Redis (bridge network). tello-mcp stays local (macOS Docker can't reach the drone via UDP). Both services use streamable-http transport. Claude Code connects to both via HTTP URLs in `.mcp.json`.
+
+**Tech Stack:** Docker, Docker Compose, uv (multi-stage build), FastMCP 3.1.0 custom_route, Starlette
+
+**Spec:** `docs/superpowers/specs/2026-03-20-phase4d-containerization-design.md`
+
+---
+
+### Task 1: Make Neo4j optional in BaseServiceConfig (TDD)
+
+**Files:**
+- Modify: `packages/tello-core/src/tello_core/config.py:1-78`
+- Modify: `packages/tello-core/tests/test_config.py:1-84`
+- Modify: `packages/tello-core/tests/conftest.py:1-17`
+
+- [ ] **Step 1: Write failing tests for optional Neo4j**
+
+Add to `packages/tello-core/tests/test_config.py`:
+
+```python
+class TestBaseServiceConfigOptionalNeo4j:
+    """Tests for require_neo4j=False subclasses."""
+
+    def test_subclass_without_neo4j_from_env(self, monkeypatch):
+        """A subclass with require_neo4j=False should not require NEO4J_* vars."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+        monkeypatch.delenv("NEO4J_URI", raising=False)
+        monkeypatch.delenv("NEO4J_USERNAME", raising=False)
+        monkeypatch.delenv("NEO4J_PASSWORD", raising=False)
+
+        @dataclass(frozen=True, slots=True)
+        class NoNeo4jConfig(BaseServiceConfig):
+            require_neo4j: ClassVar[bool] = False
+
+        config = NoNeo4jConfig.from_env(service_name="test")
+        assert config.neo4j_uri is None
+        assert config.neo4j_username is None
+        assert config.neo4j_password is None
+        assert config.redis_url == "redis://localhost:6379"
+
+    def test_subclass_without_neo4j_accepts_neo4j_if_provided(self, env_vars):
+        """When Neo4j vars ARE set, they should still be loaded."""
+        @dataclass(frozen=True, slots=True)
+        class NoNeo4jConfig(BaseServiceConfig):
+            require_neo4j: ClassVar[bool] = False
+
+        config = NoNeo4jConfig.from_env(service_name="test")
+        assert config.neo4j_uri == "bolt://localhost:7687"
+
+    def test_base_class_still_requires_neo4j(self, monkeypatch):
+        """Default require_neo4j=True behavior unchanged."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+        monkeypatch.delenv("NEO4J_URI", raising=False)
+        with pytest.raises(ConfigurationError, match="NEO4J_URI"):
+            BaseServiceConfig.from_env(service_name="test")
+```
+
+Add imports at top of test file:
+```python
+from dataclasses import dataclass
+from typing import ClassVar
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --package tello-core pytest packages/tello-core/tests/test_config.py::TestBaseServiceConfigOptionalNeo4j -v`
+Expected: FAIL — `ClassVar` not recognized, fields are required
+
+- [ ] **Step 3: Implement optional Neo4j in BaseServiceConfig**
+
+Modify `packages/tello-core/src/tello_core/config.py`:
+
+```python
+from typing import ClassVar, Self
+
+@dataclass(frozen=True, slots=True)
+class BaseServiceConfig:
+    """Base configuration shared by all platform services."""
+
+    require_neo4j: ClassVar[bool] = True
+
+    redis_url: str
+    service_name: str
+    neo4j_uri: str | None = None
+    neo4j_username: str | None = None
+    neo4j_password: str | None = None
+    neo4j_max_connection_pool_size: int = 5
+    neo4j_connection_acquisition_timeout: float = 30.0
+
+    @classmethod
+    def from_env(cls, **overrides: str | int | float | bool) -> Self:
+        """Load configuration from environment variables."""
+        values: dict[str, str | None] = {}
+
+        # Redis is always required
+        if "redis_url" in overrides:
+            values["redis_url"] = overrides.pop("redis_url")
+        else:
+            val = os.environ.get("REDIS_URL")
+            if val is None:
+                msg = "Required environment variable REDIS_URL is not set"
+                raise ConfigurationError(msg)
+            values["redis_url"] = val
+
+        # Neo4j is conditional on require_neo4j
+        neo4j_fields = {
+            "neo4j_uri": "NEO4J_URI",
+            "neo4j_username": "NEO4J_USERNAME",
+            "neo4j_password": "NEO4J_PASSWORD",
+        }
+        for field, env_var in neo4j_fields.items():
+            if field in overrides:
+                values[field] = overrides.pop(field)
+            else:
+                val = os.environ.get(env_var)
+                if val is None and cls.require_neo4j:
+                    msg = f"Required environment variable {env_var} is not set"
+                    raise ConfigurationError(msg)
+                values[field] = val
+
+        return cls(**values, **overrides)
+
+    def __post_init__(self) -> None:
+        """Fail-fast validation."""
+        if self.neo4j_uri is not None:
+            if not any(self.neo4j_uri.startswith(s) for s in VALID_NEO4J_SCHEMES):
+                msg = f"Neo4j URI must start with one of {VALID_NEO4J_SCHEMES}, got: {self.neo4j_uri}"
+                raise ConfigurationError(msg)
+        if not any(self.redis_url.startswith(s) for s in VALID_REDIS_SCHEMES):
+            msg = f"Redis URL must start with one of {VALID_REDIS_SCHEMES}, got: {self.redis_url}"
+            raise ConfigurationError(msg)
+        if not self.service_name:
+            msg = "service_name must be non-empty"
+            raise ConfigurationError(msg)
+```
+
+- [ ] **Step 4: Verify existing tests and downstream code**
+
+The field order changed: `redis_url` and `service_name` are now before the Neo4j fields. Verify:
+- All `BaseServiceConfig(...)` constructor calls use keyword arguments (they already do — confirm no positional args)
+- The `mock_config` fixture in `services/tello-mcp/tests/conftest.py` still works (it passes Neo4j values via kwargs — should be fine)
+- No downstream code calls `config.neo4j_uri` without handling `None` when `require_neo4j=False` (tello-mcp never opens a Neo4j connection, so this should be safe)
+
+- [ ] **Step 5: Run all tello-core tests**
+
+Run: `uv run --package tello-core pytest packages/tello-core/tests/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Set require_neo4j = False on TelloMcpConfig**
+
+Modify `services/tello-mcp/src/tello_mcp/config.py`, add import and class var:
+
+```python
+from typing import ClassVar, Self
+```
+
+Add to `TelloMcpConfig` class body:
+```python
+    require_neo4j: ClassVar[bool] = False
+```
+
+- [ ] **Step 7: Run tello-mcp tests to verify no regression**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 8: Run all tests across workspace**
+
+Run: `uv run --package tello-core pytest packages/tello-core/tests/ -v && uv run --package tello-mcp pytest services/tello-mcp/tests/ -v && uv run --package tello-telemetry pytest services/tello-telemetry/tests/ -v && uv run --package tello-navigator pytest services/tello-navigator/tests/ -v`
+Expected: ALL PASS (334+ tests)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/tello-core/src/tello_core/config.py packages/tello-core/tests/test_config.py services/tello-mcp/src/tello_mcp/config.py
+git commit -m "refactor: make Neo4j optional in BaseServiceConfig"
+```
+
+---
+
+### Task 2: Add health endpoint to tello-telemetry (TDD)
+
+**Files:**
+- Modify: `services/tello-telemetry/src/tello_telemetry/server.py:1-95`
+- Create: `services/tello-telemetry/tests/test_health.py`
+
+- [ ] **Step 1: Write failing test for health endpoint**
+
+Create `services/tello-telemetry/tests/test_health.py`:
+
+```python
+"""Tests for tello-telemetry health endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.testclient import TestClient
+
+from tello_telemetry.server import mcp
+
+
+class TestHealthEndpoint:
+    @pytest.fixture()
+    def client(self):
+        """Create a Starlette test client from the FastMCP HTTP app."""
+        app = mcp.http_app()
+        return TestClient(app)
+
+    def test_health_returns_200_when_healthy(self, client, monkeypatch):
+        """Health endpoint returns 200 with redis=true, neo4j=true."""
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(return_value=True)
+        mock_neo4j = MagicMock()
+        mock_neo4j.verify_connectivity = MagicMock(return_value=None)
+
+        monkeypatch.setattr(
+            "tello_telemetry.server._health_deps",
+            lambda: (mock_redis, mock_neo4j),
+        )
+
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["redis"] is True
+        assert data["neo4j"] is True
+
+    def test_health_returns_503_when_redis_down(self, client, monkeypatch):
+        """Health endpoint returns 503 when Redis is unreachable."""
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(side_effect=ConnectionError("refused"))
+        mock_neo4j = MagicMock()
+        mock_neo4j.verify_connectivity = MagicMock(return_value=None)
+
+        monkeypatch.setattr(
+            "tello_telemetry.server._health_deps",
+            lambda: (mock_redis, mock_neo4j),
+        )
+
+        response = client.get("/health")
+        assert response.status_code == 503
+        data = response.json()
+        assert data["redis"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --package tello-telemetry pytest services/tello-telemetry/tests/test_health.py -v`
+Expected: FAIL — `_health_deps` does not exist, no `/health` route
+
+- [ ] **Step 3: Implement health endpoint**
+
+Modify `services/tello-telemetry/src/tello_telemetry/server.py`. Add imports at top:
+
+```python
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+```
+
+Add a module-level variable and helper after the `mcp` definition:
+
+```python
+_redis_client = None
+_neo4j_driver = None
+
+
+def _health_deps():
+    """Return (redis, neo4j) clients for health check. Overridable for testing."""
+    return (_redis_client, _neo4j_driver)
+```
+
+Add the health route after `queries.register(mcp)`:
+
+```python
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(request: Request) -> JSONResponse:
+    """Health check endpoint for Docker healthcheck."""
+    redis, neo4j = _health_deps()
+    redis_ok = False
+    neo4j_ok = False
+
+    if redis is not None:
+        try:
+            await redis.ping()
+            redis_ok = True
+        except Exception:
+            pass
+
+    if neo4j is not None:
+        try:
+            # verify_connectivity() is sync but fast; acceptable for infrequent health checks
+            neo4j.verify_connectivity()
+            neo4j_ok = True
+        except Exception:
+            pass
+
+    healthy = redis_ok and neo4j_ok
+    status_code = 200 if healthy else 503
+    return JSONResponse(
+        {"status": "ok" if healthy else "degraded", "redis": redis_ok, "neo4j": neo4j_ok},
+        status_code=status_code,
+    )
+```
+
+Update the `lifespan` function to set and clean up module-level clients:
+
+```python
+    redis = create_redis_client(config.redis_url)
+    global _redis_client  # noqa: PLW0603
+    _redis_client = redis
+    async with neo4j_lifespan(config) as neo4j_driver:
+        global _neo4j_driver  # noqa: PLW0603
+        _neo4j_driver = neo4j_driver
+        # ... existing yield and finally ...
+        # Add to the finally block, after await redis.aclose():
+        _redis_client = None
+        _neo4j_driver = None
+```
+
+- [ ] **Step 4: Run health tests**
+
+Run: `uv run --package tello-telemetry pytest services/tello-telemetry/tests/test_health.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Run all tello-telemetry tests**
+
+Run: `uv run --package tello-telemetry pytest services/tello-telemetry/tests/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/tello-telemetry/src/tello_telemetry/server.py services/tello-telemetry/tests/test_health.py
+git commit -m "feat: add /health endpoint to tello-telemetry"
+```
+
+---
+
+### Task 3: Create Dockerfile and .dockerignore
+
+**Files:**
+- Create: `services/tello-telemetry/Dockerfile`
+- Create: `.dockerignore`
+
+- [ ] **Step 1: Create .dockerignore**
+
+Create `.dockerignore` at repo root:
+
+```
+.git/
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+.claude/
+docs/
+.env
+.mcp.json
+.ruff_cache/
+.pytest_cache/
+*.egg-info/
+**/tests/
+**/test_*/
+.gitignore
+*.md
+LICENSE
+```
+
+- [ ] **Step 2: Create Dockerfile for tello-telemetry**
+
+Create `services/tello-telemetry/Dockerfile`:
+
+```dockerfile
+# Stage 1: Build dependencies with uv
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+
+WORKDIR /app
+
+# Copy workspace root files for dependency resolution
+COPY pyproject.toml uv.lock ./
+
+# Copy only the packages needed by tello-telemetry
+COPY packages/tello-core/ packages/tello-core/
+COPY services/tello-telemetry/ services/tello-telemetry/
+
+# Install production dependencies only
+RUN uv sync --package tello-telemetry --frozen --no-dev
+
+# Stage 2: Slim runtime image
+FROM python:3.13-slim-bookworm
+
+WORKDIR /app
+
+# Install curl for Docker healthcheck
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
+
+# Copy source code
+COPY packages/tello-core/src/ packages/tello-core/src/
+COPY services/tello-telemetry/src/ services/tello-telemetry/src/
+
+# Activate venv
+ENV PATH="/app/.venv/bin:$PATH"
+
+EXPOSE 8200
+
+ENTRYPOINT ["python", "-m", "tello_telemetry.server", "--transport", "streamable-http", "--port", "8200"]
+```
+
+- [ ] **Step 3: Test the Docker build**
+
+Run: `docker compose build tello-telemetry`
+Expected: Build succeeds (will fail because compose doesn't have the service yet — that's Task 4. Build standalone instead.)
+
+Run: `docker build -f services/tello-telemetry/Dockerfile -t tello-telemetry:test .`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .dockerignore services/tello-telemetry/Dockerfile
+git commit -m "feat: add Dockerfile and .dockerignore for tello-telemetry"
+```
+
+---
+
+### Task 4: Add tello-telemetry to docker-compose.yml
+
+**Files:**
+- Modify: `docker-compose.yml:1-31`
+
+- [ ] **Step 1: Add tello-telemetry service to docker-compose.yml**
+
+Add after the `redis` service block, before the `volumes` block:
+
+```yaml
+  tello-telemetry:
+    build:
+      context: .
+      dockerfile: services/tello-telemetry/Dockerfile
+    ports:
+      - "8200:8200"
+    env_file: .env
+    environment:
+      REDIS_URL: redis://redis:6379
+      NEO4J_URI: bolt://neo4j:7687
+    depends_on:
+      redis:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8200/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+```
+
+- [ ] **Step 2: Build and start all services**
+
+Run: `docker compose up -d --build`
+Expected: All 3 services start. tello-telemetry waits for redis + neo4j health.
+
+- [ ] **Step 3: Verify tello-telemetry is healthy**
+
+Run: `docker compose ps`
+Expected: tello-telemetry shows "healthy" status
+
+Run: `curl -s http://localhost:8200/health | python3 -m json.tool`
+Expected: `{"status": "ok", "redis": true, "neo4j": true}`
+
+- [ ] **Step 4: Verify tello-telemetry MCP endpoint responds**
+
+Run: `curl -s -X POST http://localhost:8200/mcp -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}},"id":1}'`
+Expected: JSON response with server capabilities
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "feat: add tello-telemetry to Docker Compose"
+```
+
+---
+
+### Task 5: Update .mcp.json to HTTP transport
+
+**Files:**
+- Modify: `.mcp.json:1-37`
+
+- [ ] **Step 1: Update .mcp.json**
+
+Replace entire file content:
+
+```json
+{
+  "mcpServers": {
+    "neo4j": {
+      "type": "stdio",
+      "command": "neo4j-mcp",
+      "args": ["--neo4j-read-only", "true"],
+      "env": {
+        "NEO4J_URI": "bolt://localhost:7687",
+        "NEO4J_USERNAME": "neo4j",
+        "NEO4J_PASSWORD": "${NEO4J_PASSWORD:-claude-code-memory}"
+      }
+    },
+    "memory": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic/mcp-neo4j-memory"],
+      "env": {
+        "NEO4J_URI": "bolt://localhost:7689",
+        "NEO4J_USERNAME": "neo4j",
+        "NEO4J_PASSWORD": "${NEO4J_PASSWORD:-claude-code-memory}"
+      }
+    },
+    "tello-mcp": {
+      "type": "http",
+      "url": "http://localhost:8100/mcp"
+    },
+    "tello-telemetry": {
+      "type": "http",
+      "url": "http://localhost:8200/mcp"
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Verify .env contains all tello-mcp env vars**
+
+Since `.mcp.json` no longer passes env vars to tello-mcp, they must be in `.env`. Verify `.env` contains:
+- `REDIS_URL=redis://localhost:6379`
+- `TELLO_HOST=auto` (critical — without this, tello-mcp falls back to `192.168.10.1` which is the direct WiFi default, not Router Mode)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .mcp.json
+git commit -m "feat: switch tello-mcp to HTTP, add tello-telemetry to .mcp.json"
+```
+
+---
+
+### Task 6: Reduce keepalive interval (opportunistic)
+
+**Files:**
+- Modify: `services/tello-mcp/src/tello_mcp/server.py:30-35`
+
+- [ ] **Step 1: Change keepalive interval**
+
+In `services/tello-mcp/src/tello_mcp/server.py`, change line 33:
+
+```python
+# Before
+        await asyncio.sleep(10)
+# After
+        await asyncio.sleep(5)
+```
+
+Also update the docstring on line 31:
+```python
+# Before
+    """Send keepalive every 10s to prevent 15s auto-land timeout."""
+# After
+    """Send keepalive every 5s to prevent 15s auto-land timeout."""
+```
+
+- [ ] **Step 2: Run tello-mcp tests**
+
+Run: `uv run --package tello-mcp pytest services/tello-mcp/tests/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add services/tello-mcp/src/tello_mcp/server.py
+git commit -m "fix: reduce keepalive interval from 10s to 5s for safety margin"
+```
+
+---
+
+### Task 7: Full verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run all tests across workspace**
+
+Run: `uv run --package tello-core pytest packages/tello-core/tests/ -v && uv run --package tello-mcp pytest services/tello-mcp/tests/ -v && uv run --package tello-telemetry pytest services/tello-telemetry/tests/ -v && uv run --package tello-navigator pytest services/tello-navigator/tests/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 2: Run lint**
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+Expected: Clean
+
+- [ ] **Step 3: Rebuild and verify Docker stack**
+
+Run: `docker compose down && docker compose up -d --build`
+Expected: All 3 services healthy
+
+Run: `docker compose ps`
+Expected: neo4j (healthy), redis (healthy), tello-telemetry (healthy)
+
+Run: `curl -s http://localhost:8200/health | python3 -m json.tool`
+Expected: `{"status": "ok", "redis": true, "neo4j": true}`
+
+- [ ] **Step 4: Verify tello-telemetry logs**
+
+Run: `docker compose logs tello-telemetry --tail 20`
+Expected: structlog JSON output showing startup, Redis connection, Neo4j connection, consumer group creation
+
+---
+
+### Task 8: Create PR
+
+- [ ] **Step 1: Create PR**
+
+Include the spec document in the PR branch (unstash or re-add if needed).
+
+```bash
+git add docs/superpowers/specs/2026-03-20-phase4d-containerization-design.md docs/superpowers/plans/2026-03-20-phase4d-containerization.md
+git commit -m "docs: Phase 4d spec and implementation plan"
+```
+
+Create PR:
+```bash
+gh pr create --title "feat: Phase 4d — containerize tello-telemetry + HTTP transport" --body "$(cat <<'EOF'
+## Summary
+
+- Add tello-telemetry to Docker Compose (Dockerfile + health endpoint)
+- Switch tello-mcp to HTTP transport in .mcp.json (eliminates branch/cwd problem)
+- Add tello-telemetry query tools to .mcp.json
+- Make Neo4j optional in BaseServiceConfig (tello-mcp doesn't use it)
+- Reduce keepalive interval from 10s to 5s
+
+Closes #TBD
+
+## Post-merge startup
+
+```bash
+docker compose up -d    # Neo4j + Redis + tello-telemetry
+export $(grep -v '^#' .env | xargs)
+uv run --package tello-mcp python -m tello_mcp.server --transport streamable-http
+# Then start Claude Code
+```
+
+## Test plan
+
+- [ ] All unit tests pass (334+)
+- [ ] Lint clean
+- [ ] `docker compose up -d --build` starts all 3 services healthy
+- [ ] `curl http://localhost:8200/health` returns 200
+- [ ] tello-telemetry MCP endpoint responds
+- [ ] Physical flight test: FlightSession + ObstacleIncident in Neo4j
+
+EOF
+)"
+```
+
+Expected: PR created, CI runs

--- a/docs/superpowers/specs/2026-03-20-phase4d-containerization-design.md
+++ b/docs/superpowers/specs/2026-03-20-phase4d-containerization-design.md
@@ -1,0 +1,177 @@
+# Phase 4d: Containerization — tello-telemetry + HTTP Transport
+
+**Date:** 2026-03-20
+**Phase:** 4d
+**Status:** Draft
+**Depends on:** Phase 4c (merged, PR #25)
+
+## Problem Statement
+
+Physical testing of the drone requires multiple services running simultaneously: Neo4j, Redis, tello-mcp, and tello-telemetry. The current startup process is entirely manual and has caused repeated test failures:
+
+1. **Forgotten telemetry** — tello-telemetry must be started in a separate terminal with manual env var export. It has been forgotten in multiple test sessions, resulting in zero flight data captured.
+2. **Wrong branch** — `.mcp.json` runs tello-mcp from `cwd: "."`, so it executes whatever code is checked out. During Phase 4c testing, the MCP server ran main-branch code instead of the PR branch, invalidating the test.
+3. **Battery drain** — Each manual startup failure burns drone battery time during troubleshooting. The battery went from 42% to 18% during today's failed test setup before a single test maneuver could complete.
+4. **Env var duplication** — `.env`, `.mcp.json`, and `docker-compose.yml` contain overlapping env vars with inconsistent defaults.
+
+## Constraints
+
+- **Docker Desktop on macOS cannot reach the drone.** Tested and confirmed: `docker run --network host --rm alpine ping -c 3 <drone-ip>` shows 100% packet loss. Docker Desktop runs containers in a Linux VM whose host network is the VM's network, not the Mac's physical LAN. tello-mcp needs UDP access to the drone on the LAN, so it must run locally.
+- **tello-mcp stays local.** Runs via `uv run` on the host, not in Docker. Communicates with Claude Code over HTTP (port 8100) instead of stdio.
+- **tello-telemetry moves into Docker.** It only needs Redis and Neo4j — both already in Docker on the bridge network.
+- **Scope is friction elimination, not portfolio polish.** Multi-stage Dockerfiles and health checks are included because they're best practice, but resource limits, log aggregation, and image registry publishing are deferred to a later polish pass after Phases 5 + 6.
+
+## Design
+
+### 1. Dockerfile for tello-telemetry
+
+Location: `services/tello-telemetry/Dockerfile`
+
+Multi-stage build:
+
+**Stage 1 (builder):** Base image `ghcr.io/astral-sh/uv:python3.13-bookworm-slim`. Copies `pyproject.toml`, `uv.lock`, `packages/tello-core/`, and `services/tello-telemetry/`. Runs `uv sync --package tello-telemetry --frozen --no-dev` to produce a `.venv` with production dependencies only.
+
+**Stage 2 (runtime):** Base image `python:3.13-slim-bookworm`. Copies `.venv` from builder and source code from `packages/tello-core/src/` and `services/tello-telemetry/src/`. Installs `curl` for Docker healthcheck. Sets entrypoint: `python -m tello_telemetry.server --transport streamable-http --port 8200`.
+
+### 2. .dockerignore
+
+New file at repo root. Excludes `.git/`, `.venv/`, `__pycache__/`, `.claude/`, `docs/`, `*.pyc`, `.env`, `.mcp.json`, and test directories. Keeps the Docker build context small and prevents sensitive files from entering images.
+
+Note: `.env` is excluded from the *build context* (not baked into the image) but is still loaded at *runtime* via `env_file: .env` in docker-compose.yml. These are independent mechanisms — `.dockerignore` controls what files Docker can see during `docker build`, while `env_file` injects environment variables when the container starts.
+
+### 3. docker-compose.yml — add tello-telemetry
+
+Neo4j and Redis services are unchanged. Add:
+
+```yaml
+tello-telemetry:
+  build:
+    context: .
+    dockerfile: services/tello-telemetry/Dockerfile
+  ports:
+    - "8200:8200"
+  env_file: .env
+  environment:
+    REDIS_URL: redis://redis:6379
+    NEO4J_URI: bolt://neo4j:7687
+  depends_on:
+    redis:
+      condition: service_healthy
+    neo4j:
+      condition: service_healthy
+  healthcheck:
+    test: ["CMD", "curl", "-sf", "http://localhost:8200/health"]
+    interval: 10s
+    timeout: 5s
+    retries: 3
+  restart: unless-stopped
+```
+
+`env_file: .env` loads base vars. The `environment:` block overrides `REDIS_URL` and `NEO4J_URI` to use Docker service names instead of `localhost`. This means `.env` stays unchanged for local development.
+
+`depends_on` with `condition: service_healthy` ensures tello-telemetry starts only after Redis and Neo4j pass their existing healthchecks.
+
+`restart: unless-stopped` auto-restarts the container on crash.
+
+### 4. Health endpoint for tello-telemetry
+
+Add an HTTP `/health` endpoint to the FastMCP server's ASGI app. Checks:
+
+1. **Redis** — calls `redis_health_check()` (exists in tello-core)
+2. **Neo4j** — calls `driver.verify_connectivity()`
+
+Returns HTTP 200 `{"status": "ok", "redis": true, "neo4j": true}` when healthy, HTTP 503 when either dependency is down.
+
+Implementation: Use FastMCP's `@mcp.custom_route("/health", methods=["GET"])` decorator to register the endpoint on the ASGI app.
+
+### 5. .mcp.json changes
+
+**tello-mcp:** Replace stdio config with HTTP:
+
+```json
+"tello-mcp": {
+  "type": "http",
+  "url": "http://localhost:8100/mcp"
+}
+```
+
+tello-mcp runs locally via `uv run --package tello-mcp python -m tello_mcp.server --transport streamable-http`. Claude Code connects over HTTP. This eliminates the cwd/branch problem — the HTTP URL is branch-independent.
+
+**Trade-off: manual startup.** With stdio, Claude Code auto-spawned tello-mcp. With HTTP, the operator must start tello-mcp before launching Claude Code. This is acceptable because a missing tello-mcp produces an immediate, visible connection error in Claude Code — unlike tello-telemetry, which fails silently (no flight data captured, no error shown).
+
+**Env vars for manual tello-mcp startup:** Load from `.env` using the project's existing convention: `export $(grep -v '^#' .env | xargs)` before running `uv run`. The `.mcp.json` entry no longer carries env vars — they must be in the shell environment.
+
+**tello-telemetry:** Add new entry:
+
+```json
+"tello-telemetry": {
+  "type": "http",
+  "url": "http://localhost:8200/mcp"
+}
+```
+
+Exposes tello-telemetry's 5 query tools (flight sessions, obstacle incidents, anomalies) to Claude Code.
+
+**neo4j and memory:** Unchanged.
+
+### 6. BaseServiceConfig — make Neo4j optional
+
+`BaseServiceConfig` currently requires `NEO4J_URI`, `NEO4J_USERNAME`, `NEO4J_PASSWORD` for all services. tello-mcp never opens a Neo4j connection — these vars are dead weight.
+
+Implementation details (the `BaseServiceConfig` dataclass uses `frozen=True, slots=True`, which constrains how this works):
+
+1. **Add `require_neo4j: ClassVar[bool] = True`** to `BaseServiceConfig`. `ClassVar` is excluded from `__slots__` generation by dataclasses, so this works with `slots=True`.
+2. **Change Neo4j field types** from `str` to `str | None` with default `None`. Move them after `service_name` in field order (fields with defaults must follow fields without).
+3. **Update `__post_init__`** to conditionally validate Neo4j fields: only check URI scheme and require non-empty values when `require_neo4j` is `True`.
+4. **Update `from_env`** to conditionally read Neo4j env vars: when `require_neo4j` is `False`, skip `os.environ[]` lookups for `NEO4J_URI`, `NEO4J_USERNAME`, `NEO4J_PASSWORD` (pass `None` instead).
+
+`TelloMcpConfig` overrides: `require_neo4j: ClassVar[bool] = False`.
+
+All other service configs inherit the default `True` — no behavior change for tello-telemetry or tello-navigator.
+
+### 7. Keepalive interval reduction (opportunistic)
+
+Unrelated to containerization, but included as a low-risk safety improvement while touching tello-mcp config.
+
+Change `_keepalive_loop` sleep interval in tello-mcp's `server.py` from 10 seconds to 5 seconds. The drone auto-lands after 15 seconds without a command. Reducing from 10s to 5s provides more safety margin against system load or other delays.
+
+One-line change: `await asyncio.sleep(10)` → `await asyncio.sleep(5)`.
+
+## Post-Phase 4d Startup
+
+```bash
+docker compose up -d    # Starts Neo4j + Redis + tello-telemetry
+# Power on the drone
+# Start Claude Code — connects to tello-mcp (HTTP :8100) + tello-telemetry (HTTP :8200)
+```
+
+tello-mcp must be started manually before launching Claude Code:
+```bash
+export $(grep -v '^#' .env | xargs)
+uv run --package tello-mcp python -m tello_mcp.server --transport streamable-http
+```
+
+## Out of Scope
+
+- **tello-mcp Dockerfile** — not needed until Linux deployment or CI. Can be added in ~30 minutes when needed.
+- **Resource limits** — deferred to portfolio polish pass after Phases 5 + 6.
+- **Image registry (GHCR)** — deferred. Build locally for now.
+- **Log aggregation** — `docker compose logs -f` is sufficient for development.
+- **Startup convenience script** — deferred. Two commands (`docker compose up -d` + Claude Code) is acceptable.
+- **Phase 4e (Unified Command Path)** — separate phase, unrelated to containerization.
+
+## Extension Points
+
+**Phase 5 (tello-vision):** Add a new service running locally (like tello-mcp) for UDP 11111 camera stream access. Same Docker Desktop macOS limitation applies — container can't reach the drone's video stream. Same Dockerfile pattern is available for Linux deployment.
+
+**Phase 6 (tello-voice):** Add as a bridge-network compose service. Connects to tello-mcp via HTTP — no drone network access needed.
+
+Both phases add services to the existing compose file without rearchitecting.
+
+## Testing
+
+- `docker compose up -d` starts all three services, all report healthy
+- `docker compose ps` shows tello-telemetry as healthy
+- Claude Code connects to both HTTP MCP servers
+- Fly the drone → verify FlightSession created in Neo4j with `end_time` set
+- Verify tello-telemetry query tools accessible from Claude Code

--- a/packages/tello-core/src/tello_core/config.py
+++ b/packages/tello-core/src/tello_core/config.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import ClassVar, Self
+from typing import Any, ClassVar, Self
 
 import structlog
 
@@ -52,7 +52,7 @@ class BaseServiceConfig:
         Args:
             **overrides: Values that override environment variables.
         """
-        values: dict[str, str | None] = {}
+        values: dict[str, Any] = {}
 
         # Redis is always required
         if "redis_url" in overrides:

--- a/packages/tello-core/src/tello_core/config.py
+++ b/packages/tello-core/src/tello_core/config.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Self
+from typing import ClassVar, Self
 
 import structlog
 
@@ -25,13 +25,20 @@ class BaseServiceConfig:
         @dataclass(frozen=True, slots=True)
         class TelloMcpConfig(BaseServiceConfig):
             tello_wifi_ssid: str = ""
+
+    Set require_neo4j = False on subclasses that don't use Neo4j:
+        @dataclass(frozen=True, slots=True)
+        class NoNeo4jService(BaseServiceConfig):
+            require_neo4j: ClassVar[bool] = False
     """
 
-    neo4j_uri: str
-    neo4j_username: str
-    neo4j_password: str
+    require_neo4j: ClassVar[bool] = True
+
     redis_url: str
     service_name: str
+    neo4j_uri: str | None = None
+    neo4j_username: str | None = None
+    neo4j_password: str | None = None
     neo4j_max_connection_pool_size: int = 5
     neo4j_connection_acquisition_timeout: float = 30.0
 
@@ -40,24 +47,35 @@ class BaseServiceConfig:
         """Load configuration from environment variables.
 
         Reads: NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD, REDIS_URL.
-        Raises ConfigurationError for missing required vars.
+        Raises ConfigurationError for missing required vars (Neo4j only if require_neo4j=True).
 
         Args:
             **overrides: Values that override environment variables.
         """
-        required = {
+        values: dict[str, str | None] = {}
+
+        # Redis is always required
+        if "redis_url" in overrides:
+            values["redis_url"] = overrides.pop("redis_url")  # type: ignore[assignment]
+        else:
+            val = os.environ.get("REDIS_URL")
+            if val is None:
+                msg = "Required environment variable REDIS_URL is not set"
+                raise ConfigurationError(msg)
+            values["redis_url"] = val
+
+        # Neo4j is conditional on require_neo4j
+        neo4j_fields = {
             "neo4j_uri": "NEO4J_URI",
             "neo4j_username": "NEO4J_USERNAME",
             "neo4j_password": "NEO4J_PASSWORD",
-            "redis_url": "REDIS_URL",
         }
-        values: dict[str, str] = {}
-        for field, env_var in required.items():
+        for field, env_var in neo4j_fields.items():
             if field in overrides:
-                values[field] = overrides.pop(field)
+                values[field] = overrides.pop(field)  # type: ignore[assignment]
             else:
                 val = os.environ.get(env_var)
-                if val is None:
+                if val is None and cls.require_neo4j:
                     msg = f"Required environment variable {env_var} is not set"
                     raise ConfigurationError(msg)
                 values[field] = val
@@ -66,7 +84,9 @@ class BaseServiceConfig:
 
     def __post_init__(self) -> None:
         """Fail-fast validation."""
-        if not any(self.neo4j_uri.startswith(s) for s in VALID_NEO4J_SCHEMES):
+        if self.neo4j_uri is not None and not any(
+            self.neo4j_uri.startswith(s) for s in VALID_NEO4J_SCHEMES
+        ):
             msg = f"Neo4j URI must start with one of {VALID_NEO4J_SCHEMES}, got: {self.neo4j_uri}"
             raise ConfigurationError(msg)
         if not any(self.redis_url.startswith(s) for s in VALID_REDIS_SCHEMES):

--- a/packages/tello-core/tests/test_config.py
+++ b/packages/tello-core/tests/test_config.py
@@ -1,5 +1,10 @@
 """Tests for tello_core configuration."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
 import pytest
 
 from tello_core.config import BaseServiceConfig, configure_structlog
@@ -72,6 +77,44 @@ class TestBaseServiceConfig:
         )
         assert config.neo4j_max_connection_pool_size == 5
         assert config.neo4j_connection_acquisition_timeout == 30.0
+
+
+class TestBaseServiceConfigOptionalNeo4j:
+    """Tests for require_neo4j=False subclasses."""
+
+    def test_subclass_without_neo4j_from_env(self, monkeypatch):
+        """A subclass with require_neo4j=False should not require NEO4J_* vars."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+        monkeypatch.delenv("NEO4J_URI", raising=False)
+        monkeypatch.delenv("NEO4J_USERNAME", raising=False)
+        monkeypatch.delenv("NEO4J_PASSWORD", raising=False)
+
+        @dataclass(frozen=True, slots=True)
+        class NoNeo4jConfig(BaseServiceConfig):
+            require_neo4j: ClassVar[bool] = False
+
+        config = NoNeo4jConfig.from_env(service_name="test")
+        assert config.neo4j_uri is None
+        assert config.neo4j_username is None
+        assert config.neo4j_password is None
+        assert config.redis_url == "redis://localhost:6379"
+
+    def test_subclass_without_neo4j_accepts_neo4j_if_provided(self, env_vars):
+        """When Neo4j vars ARE set, they should still be loaded."""
+
+        @dataclass(frozen=True, slots=True)
+        class NoNeo4jConfig(BaseServiceConfig):
+            require_neo4j: ClassVar[bool] = False
+
+        config = NoNeo4jConfig.from_env(service_name="test")
+        assert config.neo4j_uri == "bolt://localhost:7687"
+
+    def test_base_class_still_requires_neo4j(self, monkeypatch):
+        """Default require_neo4j=True behavior unchanged."""
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+        monkeypatch.delenv("NEO4J_URI", raising=False)
+        with pytest.raises(ConfigurationError, match="NEO4J_URI"):
+            BaseServiceConfig.from_env(service_name="test")
 
 
 class TestConfigureStructlog:

--- a/packages/tello-core/tests/test_config.py
+++ b/packages/tello-core/tests/test_config.py
@@ -21,6 +21,7 @@ class TestBaseServiceConfig:
         assert config.service_name == "test-service"
 
     def test_from_env_missing_required_var_raises(self, monkeypatch):
+        monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
         monkeypatch.delenv("NEO4J_URI", raising=False)
         with pytest.raises(ConfigurationError, match="NEO4J_URI"):
             BaseServiceConfig.from_env(service_name="test")

--- a/services/tello-mcp/src/tello_mcp/config.py
+++ b/services/tello-mcp/src/tello_mcp/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Self
+from typing import ClassVar, Self
 
 from tello_core.config import BaseServiceConfig
 
@@ -12,6 +12,8 @@ from tello_core.config import BaseServiceConfig
 @dataclass(frozen=True, slots=True)
 class TelloMcpConfig(BaseServiceConfig):
     """tello-mcp specific configuration."""
+
+    require_neo4j: ClassVar[bool] = False
 
     tello_wifi_ssid: str = ""
     tello_host: str = "192.168.10.1"

--- a/services/tello-mcp/src/tello_mcp/server.py
+++ b/services/tello-mcp/src/tello_mcp/server.py
@@ -28,9 +28,9 @@ if TYPE_CHECKING:
 
 
 async def _keepalive_loop(drone: DroneAdapter) -> None:
-    """Send keepalive every 10s to prevent 15s auto-land timeout."""
+    """Send keepalive every 5s to prevent 15s auto-land timeout."""
     while True:
-        await asyncio.sleep(10)
+        await asyncio.sleep(5)
         if drone.is_connected:
             await asyncio.to_thread(drone.keepalive)
 

--- a/services/tello-mcp/tests/conftest.py
+++ b/services/tello-mcp/tests/conftest.py
@@ -4,16 +4,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from tello_core.config import BaseServiceConfig
+from tello_mcp.config import TelloMcpConfig
 
 
 @pytest.fixture()
 def mock_config():
     """Test configuration for tello-mcp."""
-    return BaseServiceConfig(
-        neo4j_uri="bolt://localhost:7687",
-        neo4j_username="neo4j",
-        neo4j_password="test",
+    return TelloMcpConfig(
         redis_url="redis://localhost:6379",
         service_name="tello-mcp-test",
     )

--- a/services/tello-mcp/tests/test_config.py
+++ b/services/tello-mcp/tests/test_config.py
@@ -7,32 +7,33 @@ from tello_mcp.config import TelloMcpConfig
 
 
 class TestTelloMcpConfig:
-    def test_from_env(self, monkeypatch):
-        monkeypatch.setenv("NEO4J_URI", "bolt://localhost:7687")
-        monkeypatch.setenv("NEO4J_USERNAME", "neo4j")
-        monkeypatch.setenv("NEO4J_PASSWORD", "pw")
+    def test_from_env_without_neo4j(self, monkeypatch):
+        """TelloMcpConfig.from_env works without NEO4J_* env vars."""
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
         monkeypatch.setenv("TELLO_WIFI_SSID", "RMTT-TEST")
+        monkeypatch.delenv("NEO4J_URI", raising=False)
+        monkeypatch.delenv("NEO4J_USERNAME", raising=False)
+        monkeypatch.delenv("NEO4J_PASSWORD", raising=False)
 
         config = TelloMcpConfig.from_env(service_name="tello-mcp")
         assert config.tello_wifi_ssid == "RMTT-TEST"
         assert config.service_name == "tello-mcp"
+        assert config.neo4j_uri is None
+
+    def test_require_neo4j_is_false(self):
+        """TelloMcpConfig opts out of Neo4j requirement."""
+        assert TelloMcpConfig.require_neo4j is False
 
     def test_inherits_base_validation(self):
         with pytest.raises(ConfigurationError, match="Neo4j URI"):
             TelloMcpConfig(
                 neo4j_uri="http://bad",
-                neo4j_username="neo4j",
-                neo4j_password="pw",
                 redis_url="redis://localhost:6379",
                 service_name="test",
             )
 
     def test_telemetry_defaults(self):
         config = TelloMcpConfig(
-            neo4j_uri="bolt://localhost:7687",
-            neo4j_username="neo4j",
-            neo4j_password="pw",
             redis_url="redis://localhost:6379",
             service_name="test",
         )
@@ -42,20 +43,17 @@ class TestTelloMcpConfig:
 
     def test_tello_host_default(self):
         config = TelloMcpConfig(
-            neo4j_uri="bolt://localhost:7687",
-            neo4j_username="neo4j",
-            neo4j_password="pw",
             redis_url="redis://localhost:6379",
             service_name="test",
         )
         assert config.tello_host == "192.168.10.1"
 
     def test_tello_host_from_env(self, monkeypatch):
-        monkeypatch.setenv("NEO4J_URI", "bolt://localhost:7687")
-        monkeypatch.setenv("NEO4J_USERNAME", "neo4j")
-        monkeypatch.setenv("NEO4J_PASSWORD", "pw")
         monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
         monkeypatch.setenv("TELLO_HOST", "192.168.68.102")
+        monkeypatch.delenv("NEO4J_URI", raising=False)
+        monkeypatch.delenv("NEO4J_USERNAME", raising=False)
+        monkeypatch.delenv("NEO4J_PASSWORD", raising=False)
 
         config = TelloMcpConfig.from_env(service_name="tello-mcp")
         assert config.tello_host == "192.168.68.102"

--- a/services/tello-telemetry/Dockerfile
+++ b/services/tello-telemetry/Dockerfile
@@ -1,0 +1,37 @@
+# Stage 1: Build dependencies with uv
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
+
+WORKDIR /app
+
+# Copy workspace root files for dependency resolution
+COPY pyproject.toml uv.lock ./
+
+# Copy only the packages needed by tello-telemetry
+COPY packages/tello-core/ packages/tello-core/
+COPY services/tello-telemetry/ services/tello-telemetry/
+
+# Install production dependencies only
+RUN uv sync --package tello-telemetry --frozen --no-dev
+
+# Stage 2: Slim runtime image
+FROM python:3.13-slim-bookworm
+
+WORKDIR /app
+
+# Install curl for Docker healthcheck
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
+
+# Copy source code
+COPY packages/tello-core/src/ packages/tello-core/src/
+COPY services/tello-telemetry/src/ services/tello-telemetry/src/
+
+# Activate venv
+ENV PATH="/app/.venv/bin:$PATH"
+
+EXPOSE 8200
+
+ENTRYPOINT ["python", "-m", "tello_telemetry.server", "--transport", "streamable-http", "--port", "8200"]

--- a/services/tello-telemetry/src/tello_telemetry/server.py
+++ b/services/tello-telemetry/src/tello_telemetry/server.py
@@ -11,7 +11,9 @@ import asyncio
 from contextlib import asynccontextmanager, suppress
 from typing import TYPE_CHECKING
 
+import structlog
 from fastmcp import FastMCP
+from starlette.responses import JSONResponse
 
 from tello_core.config import configure_structlog
 from tello_core.neo4j_client import neo4j_lifespan
@@ -24,6 +26,10 @@ from tello_telemetry.tools import queries
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+
+    from starlette.requests import Request
+
+logger = structlog.get_logger("tello_telemetry.server")
 
 
 @asynccontextmanager
@@ -42,7 +48,11 @@ async def lifespan(server: FastMCP) -> AsyncIterator[dict]:
     configure_structlog(config.service_name)
 
     redis = create_redis_client(config.redis_url)
+    global _redis_client
+    _redis_client = redis
     async with neo4j_lifespan(config) as neo4j_driver:
+        global _neo4j_driver
+        _neo4j_driver = neo4j_driver
         detector = AnomalyDetector(config)
         session_repo = SessionRepository(neo4j_driver)
         consumer = StreamConsumer(redis, config, detector, session_repo)
@@ -55,6 +65,8 @@ async def lifespan(server: FastMCP) -> AsyncIterator[dict]:
             with suppress(asyncio.CancelledError):
                 await task
             await redis.aclose()
+            _redis_client = None
+            _neo4j_driver = None
 
 
 mcp = FastMCP(
@@ -68,6 +80,43 @@ mcp = FastMCP(
 )
 
 queries.register(mcp)
+
+_redis_client = None
+_neo4j_driver = None
+
+
+def _health_deps() -> tuple:
+    """Return (redis, neo4j) clients for health check. Overridable for testing."""
+    return (_redis_client, _neo4j_driver)
+
+
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(request: Request) -> JSONResponse:
+    """Health check endpoint for Docker healthcheck."""
+    redis, neo4j = _health_deps()
+    redis_ok = False
+    neo4j_ok = False
+
+    if redis is not None:
+        try:
+            await redis.ping()
+            redis_ok = True
+        except Exception:
+            logger.debug("health_check.redis_unreachable")
+
+    if neo4j is not None:
+        try:
+            neo4j.verify_connectivity()
+            neo4j_ok = True
+        except Exception:
+            logger.debug("health_check.neo4j_unreachable")
+
+    healthy = redis_ok and neo4j_ok
+    status_code = 200 if healthy else 503
+    return JSONResponse(
+        {"status": "ok" if healthy else "degraded", "redis": redis_ok, "neo4j": neo4j_ok},
+        status_code=status_code,
+    )
 
 
 def main() -> None:

--- a/services/tello-telemetry/src/tello_telemetry/session_repo.py
+++ b/services/tello-telemetry/src/tello_telemetry/session_repo.py
@@ -290,3 +290,42 @@ class SessionRepository:
                 """,
             )
             return [r.data() for r in records]
+
+    def get_session_obstacles(self, session_id: str) -> list[dict]:
+        """Get obstacle incidents for a session, ordered by time.
+
+        Args:
+            session_id: Session whose obstacles to retrieve.
+        """
+        with self._driver.session() as s:
+            records = s.run(
+                """
+                MATCH (oi:ObstacleIncident)-[:TRIGGERED_DURING]->
+                      (fs:FlightSession {id: $session_id})
+                RETURN oi {.*} AS incident
+                ORDER BY oi.timestamp
+                """,
+                session_id=session_id,
+            )
+            return [r.data()["incident"] for r in records]
+
+    def list_obstacle_incidents(self, limit: int = 10) -> list[dict]:
+        """List recent obstacle incidents with session info, newest first.
+
+        Args:
+            limit: Maximum number of incidents to return.
+        """
+        with self._driver.session() as s:
+            records = s.run(
+                """
+                MATCH (oi:ObstacleIncident)-[:TRIGGERED_DURING]->(fs:FlightSession)
+                RETURN oi {.*,
+                    session_id: fs.id,
+                    room_id: fs.room_id
+                } AS incident
+                ORDER BY oi.timestamp DESC
+                LIMIT $limit
+                """,
+                limit=limit,
+            )
+            return [r.data()["incident"] for r in records]

--- a/services/tello-telemetry/src/tello_telemetry/tools/queries.py
+++ b/services/tello-telemetry/src/tello_telemetry/tools/queries.py
@@ -11,7 +11,7 @@ is accessed from ctx.lifespan_context["session_repo"].
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastmcp import Context
 from mcp.types import ToolAnnotations
@@ -30,7 +30,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         annotations=ToolAnnotations(readOnlyHint=True),
     )
-    async def list_flight_sessions(ctx: Context, limit: int = 10) -> dict:
+    async def list_flight_sessions(ctx: Context, limit: int = 10) -> Any:
         """List recent flight sessions with summary stats.
 
         Args:
@@ -43,7 +43,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         annotations=ToolAnnotations(readOnlyHint=True),
     )
-    async def get_flight_session(ctx: Context, session_id: str) -> dict:
+    async def get_flight_session(ctx: Context, session_id: str) -> Any:
         """Get detailed info for one flight session.
 
         Args:
@@ -61,7 +61,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         annotations=ToolAnnotations(readOnlyHint=True),
     )
-    async def get_session_telemetry(ctx: Context, session_id: str) -> dict:
+    async def get_session_telemetry(ctx: Context, session_id: str) -> Any:
         """Get sampled telemetry curve for a session.
 
         Returns battery, altitude, temperature over time.
@@ -79,7 +79,7 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         annotations=ToolAnnotations(readOnlyHint=True),
     )
-    async def get_session_anomalies(ctx: Context, session_id: str) -> dict:
+    async def get_session_anomalies(ctx: Context, session_id: str) -> Any:
         """Get anomalies detected during a flight session.
 
         Args:
@@ -95,8 +95,40 @@ def register(mcp: FastMCP) -> None:
     @mcp.tool(
         annotations=ToolAnnotations(readOnlyHint=True),
     )
-    async def get_anomaly_summary(ctx: Context) -> dict:
+    async def get_anomaly_summary(ctx: Context) -> Any:
         """Get anomaly counts by type across all sessions."""
         repo = ctx.lifespan_context["session_repo"]
         summary = await asyncio.to_thread(repo.get_anomaly_summary)
         return {"summary": summary}
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def get_session_obstacles(ctx: Context, session_id: str) -> Any:
+        """Get obstacle incidents detected during a flight session.
+
+        Args:
+            session_id: The session to get obstacle incidents for.
+        """
+        repo = ctx.lifespan_context["session_repo"]
+        incidents = await asyncio.to_thread(
+            repo.get_session_obstacles,
+            session_id,
+        )
+        return {"incidents": incidents, "count": len(incidents)}
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def list_obstacle_incidents(ctx: Context, limit: int = 10) -> Any:
+        """List recent obstacle incidents across all sessions.
+
+        Args:
+            limit: Maximum number of incidents to return (default 10).
+        """
+        repo = ctx.lifespan_context["session_repo"]
+        incidents = await asyncio.to_thread(
+            repo.list_obstacle_incidents,
+            limit,
+        )
+        return {"incidents": incidents, "count": len(incidents)}

--- a/services/tello-telemetry/tests/test_health.py
+++ b/services/tello-telemetry/tests/test_health.py
@@ -52,3 +52,17 @@ class TestHealthEndpoint:
         assert response.status_code == 503
         data = response.json()
         assert data["redis"] is False
+
+    def test_health_returns_503_when_not_started(self, client, monkeypatch):
+        """Health endpoint returns 503 before lifespan completes."""
+        monkeypatch.setattr(
+            "tello_telemetry.server._health_deps",
+            lambda: (None, None),
+        )
+
+        response = client.get("/health")
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "degraded"
+        assert data["redis"] is False
+        assert data["neo4j"] is False

--- a/services/tello-telemetry/tests/test_health.py
+++ b/services/tello-telemetry/tests/test_health.py
@@ -1,0 +1,54 @@
+"""Tests for tello-telemetry health endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.testclient import TestClient
+
+from tello_telemetry.server import mcp
+
+
+class TestHealthEndpoint:
+    @pytest.fixture()
+    def client(self):
+        """Create a Starlette test client from the FastMCP HTTP app."""
+        app = mcp.http_app()
+        return TestClient(app)
+
+    def test_health_returns_200_when_healthy(self, client, monkeypatch):
+        """Health endpoint returns 200 with redis=true, neo4j=true."""
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(return_value=True)
+        mock_neo4j = MagicMock()
+        mock_neo4j.verify_connectivity = MagicMock(return_value=None)
+
+        monkeypatch.setattr(
+            "tello_telemetry.server._health_deps",
+            lambda: (mock_redis, mock_neo4j),
+        )
+
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["redis"] is True
+        assert data["neo4j"] is True
+
+    def test_health_returns_503_when_redis_down(self, client, monkeypatch):
+        """Health endpoint returns 503 when Redis is unreachable."""
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(side_effect=ConnectionError("refused"))
+        mock_neo4j = MagicMock()
+        mock_neo4j.verify_connectivity = MagicMock(return_value=None)
+
+        monkeypatch.setattr(
+            "tello_telemetry.server._health_deps",
+            lambda: (mock_redis, mock_neo4j),
+        )
+
+        response = client.get("/health")
+        assert response.status_code == 503
+        data = response.json()
+        assert data["redis"] is False

--- a/services/tello-telemetry/tests/test_session_repo.py
+++ b/services/tello-telemetry/tests/test_session_repo.py
@@ -195,3 +195,38 @@ class TestGetAnomalySummary:
         result = repo.get_anomaly_summary()
         assert len(result) == 1
         assert result[0]["count"] == 5
+
+
+class TestGetSessionObstacles:
+    def test_returns_obstacle_list(self, repo, mock_session):
+        record = MagicMock()
+        record.data.return_value = {
+            "incident": {
+                "id": "inc-1",
+                "forward_distance_mm": 185,
+                "zone": "DANGER",
+                "response": "RETURN_TO_HOME",
+            },
+        }
+        mock_session.run.return_value = [record]
+        result = repo.get_session_obstacles("sess-1")
+        assert len(result) == 1
+        assert result[0]["zone"] == "DANGER"
+        assert result[0]["forward_distance_mm"] == 185
+
+
+class TestListObstacleIncidents:
+    def test_returns_incident_list(self, repo, mock_session):
+        record = MagicMock()
+        record.data.return_value = {
+            "incident": {
+                "id": "inc-1",
+                "forward_distance_mm": 136,
+                "session_id": "sess-1",
+                "room_id": "living_room",
+            },
+        }
+        mock_session.run.return_value = [record]
+        result = repo.list_obstacle_incidents(limit=5)
+        assert len(result) == 1
+        assert result[0]["session_id"] == "sess-1"

--- a/services/tello-telemetry/tests/test_tools/test_queries.py
+++ b/services/tello-telemetry/tests/test_tools/test_queries.py
@@ -46,6 +46,8 @@ class TestQueryTools:
             "get_session_telemetry",
             "get_session_anomalies",
             "get_anomaly_summary",
+            "get_session_obstacles",
+            "list_obstacle_incidents",
         }
         assert set(self.registered_tools.keys()) == expected
 


### PR DESCRIPTION
## Summary

- Containerize tello-telemetry in Docker Compose (multi-stage Dockerfile + `/health` endpoint)
- Switch tello-mcp from stdio to HTTP transport in `.mcp.json` (eliminates cwd/branch problem)
- Add tello-telemetry query tools to `.mcp.json` (HTTP, port 8200)
- Make Neo4j optional in `BaseServiceConfig` via `require_neo4j` ClassVar (tello-mcp doesn't use it)
- Reduce keepalive interval from 10s to 5s for better safety margin

Closes #26

## Post-merge startup

```bash
docker compose up -d    # Neo4j + Redis + tello-telemetry
export $(grep -v '^#' .env | xargs)
uv run --package tello-mcp python -m tello_mcp.server --transport streamable-http
# Then start Claude Code
```

## Test plan

- [x] All unit tests pass (341: 68 core + 167 mcp + 52 telemetry + 54 navigator)
- [x] Lint + format clean
- [x] `docker compose up -d --build` starts all 3 services healthy
- [x] `curl http://localhost:8200/health` returns `{"status": "ok", "redis": true, "neo4j": true}`
- [x] tello-telemetry MCP endpoint responds
- [ ] Physical flight test: FlightSession + ObstacleIncident in Neo4j

🤖 Generated with [Claude Code](https://claude.com/claude-code)